### PR TITLE
Add TryGetAnimation to SpriteSheet

### DIFF
--- a/source/MonoGame.Extended/Graphics/SpriteSheet.cs
+++ b/source/MonoGame.Extended/Graphics/SpriteSheet.cs
@@ -73,6 +73,8 @@ public class SpriteSheet
 
     public SpriteSheetAnimation GetAnimation(string name) => _animations[name];
 
+    public bool TryGetAnimation(string name, out SpriteSheetAnimation animation) => _animations.TryGetValue(name, out animation);
+
     /// <summary>
     /// Removes the animation definition with the specified name.
     /// </summary>


### PR DESCRIPTION
## Description

* Briefly describe the purpose of this pull request and the problem it solves.

Adds TryGetAnimation, a passthrough for TryGetValue against the underlying dictionary of SpriteSheetAnimation objects. This seems useful for anyone (myself include) trying to programmatically create their animations and then, say, generate AnimatedSprites based on those definitions. The existing GetAnimation needs to be wrapped in a try/catch to avoid throwing KeyNotFoundException, which has suboptimal performance characteristics vs. TryGetValue on the underlying dictionary.

## Related Issues/Tickets

* Link to any relevant issues, bug reports, or feature requests.
* Specify if this PR closes any issues. (e.g. closes #000)

## Changes Made

* Provide a high-level overview of the technical changes.

## Checklist

Please read and check the following items.  Pull requests will not be reviewed if all items are not checked.

* [X] I have verified that there are no existing pull requests that would overlap with this pull request.
* [X] I have verified that I am following the guidelines as outlined in this project's contribution policy
* [X] I have verified that this pull request adheres to this project's code of conduct.
* [X] I have written a descriptive title for this pull request.
* [X] I have provided appropriate test coverage where applicable.