### PR TITLE
Resolve issue where LDtk level grid size was ignored if different than default grid size in project

### DIFF
--- a/source/MonoGame.Extended/Tilemaps/LDtk/Converters/LDtkTilemapDataConverter.cs
+++ b/source/MonoGame.Extended/Tilemaps/LDtk/Converters/LDtkTilemapDataConverter.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Text;
 using System.Text.Json;
 using Microsoft.Xna.Framework;
+using MonoGame.Extended.Collisions.Layers;
 using MonoGame.Extended.Tilemaps.LDtk.Document;
 using MonoGame.Extended.Tilemaps.Parsers;
 
@@ -15,12 +16,13 @@ internal static class LDtkTilemapDataConverter
         ArgumentNullException.ThrowIfNull(level);
         ArgumentNullException.ThrowIfNull(project);
 
-        int tileSize = project.DefaultGridSize > 0 ? project.DefaultGridSize : 16;
+        int tileSize = GetLevelGridSize(level, project);
+        Point levelSize = GetLevelSize(level, tileSize);
 
         TilemapData data = new TilemapData();
         data.Name = level.Identifier ?? "Untitled";
-        data.Width = level.PxWid / tileSize;
-        data.Height = level.PxHei / tileSize;
+        data.Width = levelSize.X;
+        data.Height = levelSize.Y;
         data.TileWidth = tileSize;
         data.TileHeight = tileSize;
         // LDtk only supports orthogonal maps.
@@ -37,6 +39,48 @@ internal static class LDtkTilemapDataConverter
 
         return data;
     }
+
+    private static int GetLevelGridSize(LDtkLevel level, LDtkProject project)
+    {
+        if (level.LayerInstances != null)
+        {
+            foreach (LDtkLayerInstance layer in level.LayerInstances)
+            {
+                if (layer.Type == "Entities" || layer.GridSize <= 0)
+                {
+                    continue;
+                }
+
+                return layer.GridSize;
+            }
+        }
+
+        return project.DefaultGridSize > 0 ? project.DefaultGridSize : 16;
+    }
+
+    private static Point GetLevelSize(LDtkLevel level, int tileSize)
+    {
+        if (level.LayerInstances != null)
+        {
+            foreach (LDtkLayerInstance layer in level.LayerInstances)
+            {
+                if (layer.Type == "Entities" || layer.CWid <= 0 || layer.CHei <= 0)
+                {
+                    continue;
+                }
+
+                // TODO: For now, treating LDtk levels as single-grid maps. 
+                //       Might need to revisit if mixed-grid levels cause issues with
+                //       per-layer cell sizes.
+                return new Point(layer.CWid, layer.CHei);
+            }
+        }
+
+        int x = tileSize <= 0 ? 0 : (tileSize + level.PxWid - 1) / tileSize;
+        int y = tileSize <= 0 ? 0 : (tileSize + level.PxHei - 1) / tileSize;
+        return new Point(x, y);
+    }
+
 
     #region Tilesets
 

--- a/tests/MonoGame.Extended.Tests/Tilemaps/LDtkJsonParserTests.cs
+++ b/tests/MonoGame.Extended.Tests/Tilemaps/LDtkJsonParserTests.cs
@@ -335,6 +335,73 @@ public class LDtkJsonParserTests
         Assert.Contains(tilemaps, t => t.Name == "Tiles_and_intgrid");
     }
 
+    // Regression test for issue #1159
+    // Previously the LDtk parser would only use the defaultGridSize and ignore the actual
+    // level grid size if it was different, leading to incorrect rendering.
+    [Fact]
+    public void ParseFromStream_WithLayerGridSizeDifferentFromDefault_UsesLayerGridSize()
+    {
+        LDtkJsonParser parser = new LDtkJsonParser();
+        string json = @"{
+            ""jsonVersion"": ""1.5.3"",
+            ""defaultGridSize"": 16,
+            ""levels"": [
+                {
+                    ""identifier"": ""Level_0"",
+                    ""iid"": ""test-iid"",
+                    ""uid"": 1,
+                    ""worldX"": 0,
+                    ""worldY"": 0,
+                    ""worldDepth"": 0,
+                    ""pxWid"": 640,
+                    ""pxHei"": 480,
+                    ""__bgColor"": ""#40465B"",
+                    ""layerInstances"": [
+                        {
+                            ""__identifier"": ""Tiles"",
+                            ""__type"": ""Tiles"",
+                            ""__cWid"": 27,
+                            ""__cHei"": 20,
+                            ""__gridSize"": 24,
+                            ""__opacity"": 1.0,
+                            ""__pxTotalOffsetX"": 0,
+                            ""__pxTotalOffsetY"": 0,
+                            ""__tilesetDefUid"": null,
+                            ""iid"": ""layer-iid"",
+                            ""levelId"": 1,
+                            ""layerDefUid"": 1,
+                            ""pxOffsetX"": 0,
+                            ""pxOffsetY"": 0,
+                            ""visible"": true,
+                            ""gridTiles"": [],
+                            ""autoLayerTiles"": [],
+                            ""entityInstances"": [],
+                            ""intGridCsv"": []
+                        }
+                    ]
+                }
+            ],
+            ""defs"": {
+                ""layers"": [],
+                ""entities"": [],
+                ""tilesets"": [],
+                ""enums"": []
+            }
+        }";
+
+        byte[] bytes = System.Text.Encoding.UTF8.GetBytes(json);
+
+        using MemoryStream stream = new MemoryStream(bytes);
+
+        Tilemap tilemap = parser.ParseFromStream(stream, _graphicsDevice, ".");
+
+        Assert.Equal(27, tilemap.Width);
+        Assert.Equal(20, tilemap.Height);
+        Assert.Equal(24, tilemap.TileWidth);
+        Assert.Equal(24, tilemap.TileHeight);
+
+    }
+
     // ---- Exception quality ----
 
     [Fact]


### PR DESCRIPTION
## Description

Resolves an issue where the LDTk converter would only read the default grid size value and ignore the grid size values if they were different in actual levels.  

## Related Issues/Tickets

* Closes #1159 

## Changes Made

* Check if levels have a separate grid size when converting to internal format and use that, otherwise use the default grid size from the LDtk project

## Checklist

Please read and check the following items.  Pull requests will not be reviewed if all items are not checked.

* [x] I have verified that there are no existing pull requests that would overlap with this pull request.
* [x] I have verified that I am following the guidelines as outlined in this project's contribution policy
* [x] I have verified that this pull request adheres to this project's code of conduct.
* [x] I have written a descriptive title for this pull request.
* [x] I have provided appropriate test coverage were applicable.
