### PR TITLE
Handle empty tile gid 0 in tileset collection

### DIFF
--- a/source/MonoGame.Extended/Tilemaps/TilemapTile.cs
+++ b/source/MonoGame.Extended/Tilemaps/TilemapTile.cs
@@ -60,7 +60,10 @@ public readonly struct TilemapTile
     /// Gets the local tile ID within the specified tileset.
     /// </summary>
     /// <param name="tilesets">The collection of tilesets.</param>
-    /// <param name="tileset">When this method returns, contains the tileset that owns this tile.</param>
+    /// <param name="tileset">
+    /// When this method returns, contains the tileset that owns this tile, or
+    /// <see langword="null"/> when this tile represents the empty tile sentinel.
+    /// </param>
     /// <returns>The local tile ID within the tileset.</returns>
     public int GetLocalId(TilemapTilesetCollection tilesets, out TilemapTileset tileset)
     {

--- a/source/MonoGame.Extended/Tilemaps/TilemapTilesetCollection.cs
+++ b/source/MonoGame.Extended/Tilemaps/TilemapTilesetCollection.cs
@@ -71,9 +71,17 @@ public class TilemapTilesetCollection : IReadOnlyList<TilemapTileset>
     /// Gets the tileset that contains the specified global tile ID.
     /// </summary>
     /// <param name="globalTileId">The global tile ID.</param>
-    /// <returns>The tileset containing the tile, or <see langword="null"/> if not found.</returns>
+    /// <returns>
+    /// The tileset containing the tile, or <see langword="null"/> if the ID is 0
+    /// or no tileset contains it.
+    /// </returns>
     public TilemapTileset GetTilesetForGid(int globalTileId)
     {
+        if (globalTileId == 0)
+        {
+            return null;
+        }
+
         for (int i = 0; i < _tilesets.Count; i++)
         {
             if (_tilesets[i].ContainsGlobalId(globalTileId))
@@ -89,11 +97,20 @@ public class TilemapTilesetCollection : IReadOnlyList<TilemapTileset>
     /// Gets the local tile ID within a tileset from a global tile ID.
     /// </summary>
     /// <param name="globalTileId">The global tile ID.</param>
-    /// <param name="tileset">When this method returns, contains the tileset that owns the tile.</param>
+    /// <param name="tileset">
+    /// When this method returns, contains the tileset that owns the tile, or
+    /// <see langword="null"/> when <paramref name="globalTileId"/> is 0.
+    /// </param>
     /// <returns>The local tile ID within the tileset.</returns>
     /// <exception cref="InvalidOperationException">No tileset contains the specified global tile ID.</exception>
     public int GetLocalId(int globalTileId, out TilemapTileset tileset)
     {
+        if (globalTileId == 0)
+        {
+            tileset = null;
+            return 0;
+        }
+
         TilemapTileset foundTileset = GetTilesetForGid(globalTileId);
 
         if (foundTileset == null)

--- a/tests/MonoGame.Extended.Tests/Tilemaps/Rendering/TilemapIntegrationTests.cs
+++ b/tests/MonoGame.Extended.Tests/Tilemaps/Rendering/TilemapIntegrationTests.cs
@@ -751,7 +751,10 @@ public class TilemapIntegrationTests
             tileCount: 2,
             columns: 2,
             spacing: 0,
-            margin: 0);
+            margin: 0)
+        {
+            FirstGlobalId = 1
+        };
 
         tilemap.Tilesets.Add(tileset);
 
@@ -800,7 +803,10 @@ public class TilemapIntegrationTests
             tileCount: 1,
             columns: 1,
             spacing: 0,
-            margin: 0);
+            margin: 0)
+        {
+            FirstGlobalId = 1
+        };
 
         tilemap.Tilesets.Add(tileset);
 
@@ -876,7 +882,10 @@ public class TilemapIntegrationTests
             tileCount: 2,
             columns: 2,
             spacing: 0,
-            margin: 0);
+            margin: 0)
+        {
+            FirstGlobalId = 1
+        };
 
         tilemap.Tilesets.Add(tileset);
 
@@ -916,7 +925,10 @@ public class TilemapIntegrationTests
             tileCount: 2,
             columns: 2,
             spacing: 0,
-            margin: 0);
+            margin: 0)
+        {
+            FirstGlobalId = 1
+        };
 
         tilemap.Tilesets.Add(tileset);
 
@@ -959,7 +971,10 @@ public class TilemapIntegrationTests
             tileCount: 2,
             columns: 2,
             spacing: 0,
-            margin: 0);
+            margin: 0)
+        {
+            FirstGlobalId = 1
+        };
 
         TilemapTileData tileData = new TilemapTileData(localId: 0);
         tileData.Animation = new TilemapTileAnimation(new[]

--- a/tests/MonoGame.Extended.Tests/Tilemaps/Rendering/TilemapRendererTests.cs
+++ b/tests/MonoGame.Extended.Tests/Tilemaps/Rendering/TilemapRendererTests.cs
@@ -458,7 +458,10 @@ public class TilemapRendererTests
             tileCount: 10,
             columns: 10,
             spacing: 0,
-            margin: 0);
+            margin: 0)
+        {
+            FirstGlobalId = 1
+        };
 
         tilemap.Tilesets.Add(tileset);
 
@@ -484,7 +487,10 @@ public class TilemapRendererTests
             tileCount: 4,
             columns: 2,
             spacing: 0,
-            margin: 0);
+            margin: 0)
+        {
+            FirstGlobalId = 1
+        };
 
         tilemap.Tilesets.Add(tileset);
 

--- a/tests/MonoGame.Extended.Tests/Tilemaps/Rendering/TilemapSpriteBatchRendererTests.cs
+++ b/tests/MonoGame.Extended.Tests/Tilemaps/Rendering/TilemapSpriteBatchRendererTests.cs
@@ -281,7 +281,10 @@ public class TilemapSpriteBatchRendererTests
             tileCount: 10,
             columns: 10,
             spacing: 0,
-            margin: 0);
+            margin: 0)
+        {
+            FirstGlobalId = 1
+        };
 
         tilemap.Tilesets.Add(tileset);
 
@@ -307,7 +310,10 @@ public class TilemapSpriteBatchRendererTests
             tileCount: 4,
             columns: 2,
             spacing: 0,
-            margin: 0);
+            margin: 0)
+        {
+            FirstGlobalId = 1
+        };
 
         tilemap.Tilesets.Add(tileset);
 
@@ -345,7 +351,10 @@ public class TilemapSpriteBatchRendererTests
             tileCount: 2,
             columns: 2,
             spacing: 0,
-            margin: 0);
+            margin: 0)
+        {
+            FirstGlobalId = 1
+        };
 
         TilemapTileData tileData = new TilemapTileData(localId: 0);
         tileData.Animation = new TilemapTileAnimation(new[]

--- a/tests/MonoGame.Extended.Tests/Tilemaps/TilemapTilesetCollectionTests.cs
+++ b/tests/MonoGame.Extended.Tests/Tilemaps/TilemapTilesetCollectionTests.cs
@@ -195,4 +195,39 @@ public sealed class TilemapTilesetCollectionTests
         Assert.Equal(tileset, outTileset);
     }
 
+    // Regression tests for issue #1157
+    // Empty Tiled gid 0 must be treated as the empty no tile
+    [Fact]
+    public void GetTilesetForGid_WithEmptyTileGid_ReturnsNull()
+    {
+        TilemapTilesetCollection collection = new TilemapTilesetCollection();
+        TilemapTileset tileset = new TilemapTileset("Tileset", CreateDummyTexture(), 32, 32, 100, 10)
+        {
+            FirstGlobalId = 1
+        };
+        collection.Add(tileset);
+
+        TilemapTileset result = collection.GetTilesetForGid(0);
+
+        Assert.Null(result);
+    }
+
+    // Regression tests for issue #1157
+    // Empty Tiled gid 0 must be treated as the empty no tile
+    [Fact]
+    public void GetLocalId_WithEmptyTileGid_ReturnsZeroAndNullTileset()
+    {
+        TilemapTilesetCollection collection = new TilemapTilesetCollection();
+        TilemapTileset tileset = new TilemapTileset("Tileset", CreateDummyTexture(), 32, 32, 100, 10)
+        {
+            FirstGlobalId = 1
+        };
+        collection.Add(tileset);
+
+        int localId = collection.GetLocalId(0, out TilemapTileset outTileset);
+
+        Assert.Equal(0, localId);
+        Assert.Null(outTileset);
+    }
+
 }


### PR DESCRIPTION
## Description

* Fixes a tilemap loading issue where empty Tiled cells with global tile ID `0` could be treated like an invalid tileset lookup instead of an empty tile.

## Related Issues/Tickets

* Closes #1157 

## Changes Made

* Updated tile lookup behavior so `gid 0` is treated as the empty tile.
* Made the tileset collection return `null` for empty tiles instead of treating them like an error case.

## Checklist

Please read and check the following items. Pull requests will not be reviewed if all items are not checked.

* [x] I have verified that there are no existing pull requests that would overlap with this pull request.
* [x] I have verified that I am following the guidelines as outlined in this project's contribution policy
* [x] I have verified that this pull request adheres to this project's code of conduct.
* [x] I have written a descriptive title for this pull request.
* [x] I have provided appropriate test coverage were applicable.