### PR TITLE
Normalize particle texture paths before content load

### DIFF
--- a/source/MonoGame.Extended/Particles/ParticleEffectSerializer.cs
+++ b/source/MonoGame.Extended/Particles/ParticleEffectSerializer.cs
@@ -190,6 +190,11 @@ public static class ParticleEffectSerializer
             path = Path.GetRelativePath(baseDirectory, path);
         }
 
+        // Path needs to be normalized before loading
+        // Reference issue #1162
+        path = MonoGame.Extended.Content.ContentReaderExtensions.RemoveExtension(path.Replace('\\', '/'));
+        path = MonoGame.Extended.Content.ContentReaderExtensions.ShortenRelativePath(path);
+
         Texture2D texture = content.Load<Texture2D>(path);
         if(string.IsNullOrEmpty(texture.Name))
         {


### PR DESCRIPTION
## Description

Fixes particle effect texture loading when a texture path includes a source file extension such as `.png`. The runtime loader now resolves the path as a MonoGame content asset name instead of trying to load a `.png.xnb` file.

## Related Issues/Tickets

* Closes #1162 

## Changes Made

* Normalized particle texture paths before calling `ContentManager.Load<Texture2D>()`.

## Checklist

Please read and check the following items. Pull requests will not be reviewed if all items are not checked.

* [x] I have verified that there are no existing pull requests that would overlap with this pull request.
* [x] I have verified that I am following the guidelines as outlined in this project's contribution policy
* [x] I have verified that this pull request adheres to this project's code of conduct.
* [x] I have written a descriptive title for this pull request.
* [x] I have provided appropriate test coverage were applicable.