### PR TITLE
Honor particle's initial opacity in OpacityFastFadeModifier

### DIFF
--- a/source/MonoGame.Extended/Particles/Data/Particle.cs
+++ b/source/MonoGame.Extended/Particles/Data/Particle.cs
@@ -57,6 +57,11 @@ public unsafe struct Particle
     public float Opacity;
 
     /// <summary>
+    /// The opacity (alpha) value assigned to this particle at release time.
+    /// </summary>
+    public float InitialOpacity;
+
+    /// <summary>
     /// The rotation of this particle in radians.
     /// </summary>
     public float Rotation;

--- a/source/MonoGame.Extended/Particles/Modifiers/OpacityFastFadeModifier.cs
+++ b/source/MonoGame.Extended/Particles/Modifiers/OpacityFastFadeModifier.cs
@@ -16,20 +16,19 @@ namespace MonoGame.Extended.Particles.Modifiers;
 /// Important notes:
 /// <list type="bullet">
 ///   <item>
-///     This modifier assumes particles have a standard lifespan of 1.0 second. For particles
-///     with different lifespans, the fade effect may not complete before the particle is removed,
-///     or may become fully transparent before the particle's actual end of life.
+///     <see cref="Particle.Age"/> is normalized to the emitter's configured lifespan, so the fade
+///     completes exactly at end of life regardless of the particle's actual lifespan in seconds.
 ///   </item>
 ///   <item>
 ///     Unlike other modifiers that accumulate changes over time, this modifier directly sets
-///     the opacity value each frame based solely on the particle's age.
+///     the opacity value each frame based on the particle's age and initial opacity.
 ///   </item>
 /// </list>
 /// </remarks>
 public sealed class OpacityFastFadeModifier : Modifier
 {
     /// <summary>
-    /// Updates all particles by setting their opacity based on their age.
+    /// Updates all particles by setting their opacity based on their age and initial opacity.
     /// </summary>
     /// <inheritdoc/>
     protected internal override unsafe void Update(float elapsedSeconds, ParticleIterator iterator, int particleCount)
@@ -40,7 +39,7 @@ public sealed class OpacityFastFadeModifier : Modifier
         {
             Particle* particle = iterator.Next();
 
-            particle->Opacity = 1.0f - particle->Age;
+            particle->Opacity = particle->InitialOpacity * (1.0f - particle->Age);
         }
     }
 }

--- a/source/MonoGame.Extended/Particles/ParticleEmitter.cs
+++ b/source/MonoGame.Extended/Particles/ParticleEmitter.cs
@@ -345,6 +345,7 @@ public sealed unsafe class ParticleEmitter : IDisposable
             particle->Color[2] = color.Z;
 
             particle->Opacity = Parameters.Opacity.Value;
+            particle->InitialOpacity = particle->Opacity;
 
             Vector2 scale = Parameters.Scale.Value;
             particle->Scale[0] = scale.X;

--- a/tests/MonoGame.Extended.Tests/Particles/Modifiers/OpacityFastFadeModifierTests.cs
+++ b/tests/MonoGame.Extended.Tests/Particles/Modifiers/OpacityFastFadeModifierTests.cs
@@ -1,0 +1,41 @@
+using MonoGame.Extended.Particles;
+using MonoGame.Extended.Particles.Data;
+using MonoGame.Extended.Particles.Modifiers;
+
+namespace MonoGame.Extended.Tests.Particles.Modifiers;
+
+public sealed class OpacityFastFadeModifierTests
+{
+    [Fact]
+    public unsafe void Update_ScalesOpacityByInitialOpacityAndAge()
+    {
+        using ParticleBuffer buffer = new ParticleBuffer(1);
+        ParticleIterator releaseIterator = buffer.Release(1);
+        Particle* particle = releaseIterator.Next();
+        particle->InitialOpacity = 0.5f;
+        particle->Age = 0.25f;
+        particle->Opacity = -1f;
+
+        OpacityFastFadeModifier modifier = new OpacityFastFadeModifier();
+        modifier.Update(0f, buffer.Iterator, buffer.Count);
+
+        Particle* result = buffer.Iterator.Next();
+        Assert.Equal(0.5f * (1.0f - 0.25f), result->Opacity);
+    }
+
+    [Fact]
+    public unsafe void Update_FullInitialOpacity_MatchesPreviousBehavior()
+    {
+        using ParticleBuffer buffer = new ParticleBuffer(1);
+        ParticleIterator releaseIterator = buffer.Release(1);
+        Particle* particle = releaseIterator.Next();
+        particle->InitialOpacity = 1.0f;
+        particle->Age = 0.4f;
+
+        OpacityFastFadeModifier modifier = new OpacityFastFadeModifier();
+        modifier.Update(0f, buffer.Iterator, buffer.Count);
+
+        Particle* result = buffer.Iterator.Next();
+        Assert.Equal(0.6f, result->Opacity);
+    }
+}


### PR DESCRIPTION
## Description

OpacityFastFadeModifier previously always faded from a hard-coded 1.0 opacity regardless of the particle's release-time opacity. Particle now tracks InitialOpacity at release, and the modifier scales by it so particles released with Opacity < 1.0 fade from their actual starting value instead of jumping to full opacity.

## Related Issues/Tickets

Closes #1166

## Changes Made

Particles now track the InitialOpacity and use that value when activating the OpacityFastFadeModifier.

## Checklist

Please read and check the following items.  Pull requests will not be reviewed if all items are not checked.

* [x] I have verified that there are no existing pull requests that would overlap with this pull request.
* [x] I have verified that I am following the guidelines as outlined in this project's contribution policy
* [x] I have verified that this pull request adheres to this project's code of conduct.
* [x] I have written a descriptive title for this pull request.
* [x] I have provided appropriate test coverage were applicable.
