### PR TITLE
Always overwrite Texture2D.Name from particle texture region

### DIFF
--- a/source/MonoGame.Extended/Particles/ParticleEffectSerializer.cs
+++ b/source/MonoGame.Extended/Particles/ParticleEffectSerializer.cs
@@ -196,10 +196,7 @@ public static class ParticleEffectSerializer
         path = MonoGame.Extended.Content.ContentReaderExtensions.ShortenRelativePath(path);
 
         Texture2D texture = content.Load<Texture2D>(path);
-        if(string.IsNullOrEmpty(texture.Name))
-        {
-            texture.Name = name;
-        }
+        texture.Name = name;
 
         Rectangle bounds = reader.GetAttributeRectangle(nameof(Texture2DRegion.Bounds), default);
 

--- a/tests/MonoGame.Extended.Tests/Particles/ParticleEffectSerializerTextureTests.cs
+++ b/tests/MonoGame.Extended.Tests/Particles/ParticleEffectSerializerTextureTests.cs
@@ -1,0 +1,88 @@
+using System.IO;
+using Microsoft.Xna.Framework;
+using Microsoft.Xna.Framework.Content;
+using Microsoft.Xna.Framework.Graphics;
+using MonoGame.Extended.Particles;
+using MonoGame.Extended.Tests.Fixtures;
+
+namespace MonoGame.Extended.Tests.Particles;
+
+[Collection("GraphicsTest")]
+public sealed class ParticleEffectSerializerTextureTests
+{
+    private readonly GraphicsTestFixture _graphicsFixture;
+
+    public ParticleEffectSerializerTextureTests(GraphicsTestFixture graphicsFixture)
+    {
+        _graphicsFixture = graphicsFixture;
+    }
+
+    [Fact]
+    public void Deserialize_TextureRegion_OverwritesLoadedTextureNameWithRawXmlValue()
+    {
+        Texture2D texture = _graphicsFixture.CreatePixelTexture();
+        texture.Name = "StaleCachedName";
+
+        PresetTextureContentManager content = new PresetTextureContentManager(texture);
+
+        // Effect lives under "particles/", texture lives under a sibling "textures/" folder.
+        const string textureAttribute = "../textures/particle";
+        const string expectedLoadedAssetName = "textures/particle";
+
+        string xml =
+            $"""
+            <?xml version="1.0" encoding="utf-8"?>
+            <ParticleEffect Name="TestEffect">
+              <Emitters>
+                <ParticleEmitter Name="TestEmitter" LifeSpan="1" Offset="0,0" LayerDepth="0" ReclaimFrequency="60" Capacity="1" ModifierExecutionStrategy="Serial" RenderingOrder="FrontToBack">
+                  <TextureRegion Name="{textureAttribute}" />
+                  <Parameters />
+                  <Profile Type="PointProfile" />
+                </ParticleEmitter>
+              </Emitters>
+            </ParticleEffect>
+            """;
+
+        using MemoryStream stream = new MemoryStream();
+        using (StreamWriter writer = new StreamWriter(stream, System.Text.Encoding.UTF8, 1024, leaveOpen: true))
+        {
+            writer.Write(xml);
+        }
+        stream.Position = 0;
+
+        ParticleEffect effect = ParticleEffectSerializer.Deserialize(stream, content, baseDirectory: "particles");
+
+        // Regression for #1162 (85142e2d): the content path actually loaded is normalized.
+        Assert.Equal(expectedLoadedAssetName, content.LastRequestedAssetName);
+
+        // Regression for #1165: Texture.Name is unconditionally set to the raw XML
+        // attribute value, distinct from both the normalized load path and any stale name
+        // the loaded texture instance already had.
+        Assert.Equal(textureAttribute, effect.Emitters[0].TextureRegion.Texture.Name);
+        Assert.NotEqual(content.LastRequestedAssetName, effect.Emitters[0].TextureRegion.Texture.Name);
+    }
+
+    private sealed class PresetTextureContentManager : ContentManager
+    {
+        private readonly Texture2D _texture;
+
+        public string LastRequestedAssetName { get; private set; }
+
+        public PresetTextureContentManager(Texture2D texture) : base(new GameServiceContainer())
+        {
+            _texture = texture;
+        }
+
+        public override T Load<T>(string assetName)
+        {
+            LastRequestedAssetName = assetName;
+
+            if (typeof(T) == typeof(Texture2D))
+            {
+                return (T)(object)_texture;
+            }
+
+            return default;
+        }
+    }
+}


### PR DESCRIPTION
## Description

ReadTexture2DRegion only set the loaded Texture2D's Name when it was null/empty, so a texture already loaded (and named) in a different context via a different path would keep its stale Name. Since the particle effect resolves textures by Name, this caused subsequent loads of the same particle effect to fail with a content-not-found exception. The texture's Name is now unconditionally set to the particle texture region's declared name.


## Related Issues/Tickets

Fixes #1165

## Changes Made

Remove the non-null check that prevents the particle's texture name from being updated.

## Checklist

Please read and check the following items.  Pull requests will not be reviewed if all items are not checked.

* [x] I have verified that there are no existing pull requests that would overlap with this pull request.
* [x] I have verified that I am following the guidelines as outlined in this project's contribution policy
* [x] I have verified that this pull request adheres to this project's code of conduct.
* [x] I have written a descriptive title for this pull request.
* [x] I have provided appropriate test coverage were applicable.
