### PR TITLE
Making Platform Detection Native AOT Compatible

### DIFF
--- a/source/MonoGame.Extended/Graphics/Effects/EffectResource.cs
+++ b/source/MonoGame.Extended/Graphics/Effects/EffectResource.cs
@@ -31,6 +31,7 @@ namespace MonoGame.Extended.Graphics.Effects
         private static EffectResource _defaultEffectDx12;
         private static EffectResource _defaultEffectOgl;
         private static EffectResource _defaultEffectVk;
+        private static string _detectedShaderProfile;
 
         /// <summary>
         ///     Gets the <see cref="Effects.DefaultEffect" /> embedded into the MonoGame.Extended.Graphics library.
@@ -61,6 +62,11 @@ namespace MonoGame.Extended.Graphics.Effects
         {
             ArgumentNullException.ThrowIfNull(graphicsDevice);
 
+            if (_detectedShaderProfile != null)
+            {
+                return _detectedShaderProfile;
+            }
+
             // use reflection to figure out if Shader.Profile is OpenGL (0) or DirectX (1),
             // may need to be changed / fixed for future shader profiles
             Assembly frameworkAssembly = typeof(Game).GetTypeInfo().Assembly;
@@ -79,57 +85,89 @@ namespace MonoGame.Extended.Graphics.Effects
                     switch (Convert.ToInt32(profileValue))
                     {
                         case 0:
-                            return "ogl";
+                            return _detectedShaderProfile ??= "ogl";
                         case 1:
-                            return "dx11";
+                            return _detectedShaderProfile ??= "dx11";
                         case 2:
-                            return "dx12";
+                            return _detectedShaderProfile ??= "dx12";
                         case 80:
-                            return "vk";
+                            return _detectedShaderProfile ??= "vk";
                     }
                 }
             }
 
+            // Check assemblies as a fallback.
             if (IsOpenGlAssembly(graphicsDevice.GetType().Assembly))
             {
-                return "ogl";
+                return _detectedShaderProfile ??= "ogl";
             }
 
             if (IsDirectX12Assembly(graphicsDevice.GetType().Assembly))
             {
-                return "dx12";
+                return _detectedShaderProfile ??= "dx12";
             }
 
             if (IsDirectX11Assembly(graphicsDevice.GetType().Assembly))
             {
-                return "dx11";
+                return _detectedShaderProfile ??= "dx11";
             }
 
             if (IsVulkanAssembly(graphicsDevice.GetType().Assembly))
             {
-                return "vk";
+                return _detectedShaderProfile ??= "vk";
             }
 
             foreach (Assembly loadedAssembly in AppDomain.CurrentDomain.GetAssemblies())
             {
                 if (IsOpenGlAssembly(loadedAssembly))
                 {
-                    return "ogl";
+                    return _detectedShaderProfile ??= "ogl";
                 }
 
                 if (IsDirectX12Assembly(loadedAssembly))
                 {
-                    return "dx12";
+                    return _detectedShaderProfile ??= "dx12";
                 }
 
                 if (IsDirectX11Assembly(loadedAssembly))
                 {
-                    return "dx11";
+                    return _detectedShaderProfile ??= "dx11";
                 }
 
                 if (IsVulkanAssembly(loadedAssembly))
                 {
-                    return "vk";
+                    return _detectedShaderProfile ??= "vk";
+                }
+            }
+
+            // Perform a bytecode compatibility test.
+            // This is the fallback that will work in the case of AOT.
+            string[] profilesToTest = ["dx12", "dx11", "ogl", "vk"];
+            foreach (string profile in profilesToTest)
+            {
+                try
+                {
+                    Debug.WriteLine($"Testing shader profile: {profile}");
+
+                    // Load the embedded resource bytecode for this profile.
+                    string resourceName = $"MonoGame.Extended.Graphics.Effects.Resources.DefaultEffect.{profile}.mgfxo";
+                    byte[] bytecode = new EffectResource(resourceName).Bytecode;
+
+                    // Attempt to create an Effect.
+                    // If the GraphicsDevice is Vulkan, and we feed it OpenGL bytecode, 
+                    // the underlying driver will throw an exception.
+                    Effect testEffect = new Effect(graphicsDevice, bytecode);
+
+                    // If we reach here, the GraphicsDevice successfully parsed the bytecode.
+                    return _detectedShaderProfile ??= profile;
+                }
+                catch
+                {
+                    // Bytecode was rejected by the current graphics backend:
+                    // Try the next possibility.
+                    Debug.WriteLine($"Shader profile was rejected: {profile}");
+
+                    continue;
                 }
             }
 

--- a/source/MonoGame.Extended/Graphics/Effects/EffectResource.cs
+++ b/source/MonoGame.Extended/Graphics/Effects/EffectResource.cs
@@ -2,7 +2,6 @@ using System;
 using System.Diagnostics;
 using System.IO;
 using System.Reflection;
-using Microsoft.Xna.Framework;
 using Microsoft.Xna.Framework.Graphics;
 
 namespace MonoGame.Extended.Graphics.Effects
@@ -67,81 +66,9 @@ namespace MonoGame.Extended.Graphics.Effects
                 return _detectedShaderProfile;
             }
 
-            // use reflection to figure out if Shader.Profile is OpenGL (0) or DirectX (1),
-            // may need to be changed / fixed for future shader profiles
-            Assembly frameworkAssembly = typeof(Game).GetTypeInfo().Assembly;
-            Debug.Assert(frameworkAssembly != null);
-
-            Type shaderType = frameworkAssembly.GetType("Microsoft.Xna.Framework.Graphics.Shader");
-            if (shaderType != null)
-            {
-                TypeInfo shaderTypeInfo = shaderType.GetTypeInfo();
-                Debug.Assert(shaderTypeInfo != null);
-
-                // https://github.com/MonoGame/MonoGame/blob/develop/MonoGame.Framework/Graphics/Shader/Shader.cs#L47
-                PropertyInfo profileProperty = shaderTypeInfo.GetDeclaredProperty("Profile");
-                if (profileProperty?.GetValue(null) is object profileValue)
-                {
-                    switch (Convert.ToInt32(profileValue))
-                    {
-                        case 0:
-                            return _detectedShaderProfile ??= "ogl";
-                        case 1:
-                            return _detectedShaderProfile ??= "dx11";
-                        case 2:
-                            return _detectedShaderProfile ??= "dx12";
-                        case 80:
-                            return _detectedShaderProfile ??= "vk";
-                    }
-                }
-            }
-
-            // Check assemblies as a fallback.
-            if (IsOpenGlAssembly(graphicsDevice.GetType().Assembly))
-            {
-                return _detectedShaderProfile ??= "ogl";
-            }
-
-            if (IsDirectX12Assembly(graphicsDevice.GetType().Assembly))
-            {
-                return _detectedShaderProfile ??= "dx12";
-            }
-
-            if (IsDirectX11Assembly(graphicsDevice.GetType().Assembly))
-            {
-                return _detectedShaderProfile ??= "dx11";
-            }
-
-            if (IsVulkanAssembly(graphicsDevice.GetType().Assembly))
-            {
-                return _detectedShaderProfile ??= "vk";
-            }
-
-            foreach (Assembly loadedAssembly in AppDomain.CurrentDomain.GetAssemblies())
-            {
-                if (IsOpenGlAssembly(loadedAssembly))
-                {
-                    return _detectedShaderProfile ??= "ogl";
-                }
-
-                if (IsDirectX12Assembly(loadedAssembly))
-                {
-                    return _detectedShaderProfile ??= "dx12";
-                }
-
-                if (IsDirectX11Assembly(loadedAssembly))
-                {
-                    return _detectedShaderProfile ??= "dx11";
-                }
-
-                if (IsVulkanAssembly(loadedAssembly))
-                {
-                    return _detectedShaderProfile ??= "vk";
-                }
-            }
-
             // Perform a bytecode compatibility test.
-            // This is the fallback that will work in the case of AOT.
+            // As far as I can see, this is the only AOT-compatible approach right now.
+            // TODO: We should revisit this once we have a publicly available ShaderProfile property.
             string[] profilesToTest = ["dx12", "dx11", "ogl", "vk"];
             foreach (string profile in profilesToTest)
             {
@@ -176,56 +103,6 @@ namespace MonoGame.Extended.Graphics.Effects
 #endif
 
             throw new InvalidOperationException("Unable to determine the shader profile for the current graphics platform.");
-        }
-
-        private static bool IsOpenGlAssembly(Assembly assembly)
-        {
-            string assemblyName = assembly.GetName().Name ?? string.Empty;
-            if (assemblyName.Contains("DesktopGL", StringComparison.OrdinalIgnoreCase) ||
-                assemblyName.Contains("SDL2.GL", StringComparison.OrdinalIgnoreCase))
-            {
-                return true;
-            }
-
-            return assembly.GetType("Microsoft.Xna.Platform.Graphics.ConcreteGraphicsContextGL") != null;
-        }
-
-        private static bool IsDirectX11Assembly(Assembly assembly)
-        {
-            string assemblyName = assembly.GetName().Name ?? string.Empty;
-            if (assemblyName.Contains("WindowsDX", StringComparison.OrdinalIgnoreCase) ||
-                assemblyName.Contains("DX11", StringComparison.OrdinalIgnoreCase))
-            {
-                return true;
-            }
-
-            return assembly.GetType("Microsoft.Xna.Platform.Graphics.ConcreteGraphicsContextD3D") != null ||
-                   assembly.GetType("Microsoft.Xna.Platform.Graphics.ConcreteGraphicsContextDX") != null ||
-                   assembly.GetType("Microsoft.Xna.Platform.Graphics.ConcreteGraphicsContextDirectX") != null;
-        }
-
-        private static bool IsDirectX12Assembly(Assembly assembly)
-        {
-            string assemblyName = assembly.GetName().Name ?? string.Empty;
-            if (assemblyName.Contains("WindowsDX12", StringComparison.OrdinalIgnoreCase) ||
-                assemblyName.Contains("DX12", StringComparison.OrdinalIgnoreCase))
-            {
-                return true;
-            }
-
-            return false;
-        }
-
-        private static bool IsVulkanAssembly(Assembly assembly)
-        {
-            string assemblyName = assembly.GetName().Name ?? string.Empty;
-            if (assemblyName.Contains("DesktopVK", StringComparison.OrdinalIgnoreCase) ||
-                assemblyName.Contains("Vulkan", StringComparison.OrdinalIgnoreCase))
-            {
-                return true;
-            }
-
-            return false;
         }
 
         private readonly string _resourceName;

--- a/source/MonoGame.Extended/MonoGame.Extended.csproj
+++ b/source/MonoGame.Extended/MonoGame.Extended.csproj
@@ -5,6 +5,11 @@
         <PackageTags>monogame extended pipeline bmfont tiled texture atlas input viewport fps shapes sprite</PackageTags>
     </PropertyGroup>
 
+    <!--Enable AOT compatibility checks -->
+    <PropertyGroup>
+      <IsAotCompatible>true</IsAotCompatible>
+    </PropertyGroup>
+
     <!-- Remove the following dependency files from view in the Solution Explorer panel -->
     <ItemGroup>
       <None Remove="Graphics\Effects\Resources\DefaultEffect.dx11.mgfxo" />


### PR DESCRIPTION
## Description

* Updating platform detection in `EffectResource` to be Native AOT compatible.
* I'll rebase this once #1179 is merrged.

## Related Issues/Tickets

* Coses #1171

## Changes Made

* Removed reflection access to `Shader.Profile`.
* Removed assembly name checks.
* Added logic to test shader bytecode against available backends.

## Checklist

* [x] I have verified that there are no existing pull requests that would overlap with this pull request.
* [x] I have verified that I am following the guidelines as outlined in this project's contribution policy
* [x] I have verified that this pull request adheres to this project's code of conduct.
* [x] I have written a descriptive title for this pull request.
* [ ] I have provided appropriate test coverage were applicable.
