### PR TITLE
Cleaning up Second `TiledXmlParser` Type

### DIFF
--- a/source/MonoGame.Extended/Tilemaps/Tiled/TiledTmxParser.cs
+++ b/source/MonoGame.Extended/Tilemaps/Tiled/TiledTmxParser.cs
@@ -139,7 +139,7 @@ public class TiledTmxParser : ITilemapParser
                 throw new TilemapParseException("TMX document has no XML root element.");
             }
 
-            return TiledXmlParser.ParseMap(document.Root);
+            return TiledXElementParser.ParseTilemap(document.Root);
         }
         catch (Exception ex)
         {
@@ -175,7 +175,7 @@ public class TiledTmxParser : ITilemapParser
                         throw new TilemapParseException("TSX document has no XML root element.");
                     }
 
-                    tilesetXml = TiledXmlParser.ParseTileset(document.Root);
+                    tilesetXml = TiledXElementParser.ParseTileset(document.Root);
                 }
                 catch (Exception ex)
                 {

--- a/source/MonoGame.Extended/Tilemaps/Tiled/TiledXElementParser.cs
+++ b/source/MonoGame.Extended/Tilemaps/Tiled/TiledXElementParser.cs
@@ -2,12 +2,18 @@
 using System.Globalization;
 using System.Linq;
 using System.Xml.Linq;
+using MonoGame.Extended.Tilemaps.Tiled.Document;
 
-namespace MonoGame.Extended.Tilemaps.Tiled.Document
+namespace MonoGame.Extended.Tilemaps.Tiled
 {
-    internal static class TiledXmlParser
+    internal static class TiledXElementParser
     {
-        public static TiledMapXml ParseMap(XElement element)
+        /// <summary>
+        /// Parses Tiled tilemaps using <see cref="XDocument"/>.
+        /// </summary>
+        /// <param name="element">Root XElement of the tilemap.</param>
+        /// <returns>The parsed tilemap.</returns>
+        public static TiledMapXml ParseTilemap(XElement element)
         {
             var map = new TiledMapXml
             {
@@ -75,6 +81,11 @@ namespace MonoGame.Extended.Tilemaps.Tiled.Document
             return map;
         }
 
+        /// <summary>
+        /// Parses Tiled tilesets using <see cref="XDocument"/>.
+        /// </summary>
+        /// <param name="element">Root XElement of the tileset.</param>
+        /// <returns>The parsed tileset.</returns>
         public static TiledTilesetXml ParseTileset(XElement element)
         {
             var tileset = new TiledTilesetXml();


### PR DESCRIPTION
## Description

* Renaming the stupidly named `TiledXmlParser` as `TiledXElementParser`.

## Related Issues/Tickets

* Closes #1184

## Changes Made

* Renamed my stupid `TiledXmlParser` as `TiledXElementParser`.
* Also moved it outside the `Document` folder.
* Also added XML comments in the public functions.

## Checklist

Please read and check the following items.  Pull requests will not be reviewed if all items are not checked.

* [x] I have verified that there are no existing pull requests that would overlap with this pull request.
* [x] I have verified that I am following the guidelines as outlined in this project's contribution policy
* [x] I have verified that this pull request adheres to this project's code of conduct.
* [x] I have written a descriptive title for this pull request.
* [ ] I have provided appropriate test coverage were applicable.
