### PR TITLE
Add NativeAOT registration for tilemap readers

### DIFF
--- a/source/MonoGame.Extended/Tilemaps/Content/TilemapReader.cs
+++ b/source/MonoGame.Extended/Tilemaps/Content/TilemapReader.cs
@@ -8,6 +8,21 @@ namespace MonoGame.Extended.Tilemaps.Content;
 /// </summary>
 public sealed class TilemapReader : ContentTypeReader<Tilemap>
 {
+#if !FNA && !KNI
+    /// <summary>
+    /// Registers this <see cref="ContentTypeReader"/> with the <see cref="ContentTypeReaderManager"/>
+    /// so it is resolved without reflection.
+    /// </summary>
+    /// <remarks>
+    /// Call this method once during application startup when publishing with
+    /// <c>PublishAot</c> or <c>PublishTrimmed</c>.
+    /// </remarks>
+    public static void Register() =>
+        ContentTypeReaderManager.AddTypeCreator(
+            typeof(TilemapReader).AssemblyQualifiedName,
+            () => new TilemapReader());
+#endif
+
     /// <inheritdoc/>
     protected override Tilemap Read(ContentReader reader, Tilemap existingInstance)
     {

--- a/source/MonoGame.Extended/Tilemaps/Content/TilemapTilesetReader.cs
+++ b/source/MonoGame.Extended/Tilemaps/Content/TilemapTilesetReader.cs
@@ -11,6 +11,21 @@ namespace MonoGame.Extended.Tilemaps.Content
     /// </summary>
     public sealed class TilemapTilesetReader : ContentTypeReader<TilemapTileset>
     {
+#if !FNA && !KNI
+        /// <summary>
+        /// Registers this <see cref="ContentTypeReader"/> with the <see cref="ContentTypeReaderManager"/>
+        /// so it is resolved without reflection.
+        /// </summary>
+        /// <remarks>
+        /// Call this method once during application startup when publishing with
+        /// <c>PublishAot</c> or <c>PublishTrimmed</c>.
+        /// </remarks>
+        public static void Register() =>
+            ContentTypeReaderManager.AddTypeCreator(
+                typeof(TilemapTilesetReader).AssemblyQualifiedName,
+                () => new TilemapTilesetReader());
+#endif
+
         /// <inheritdoc/>
         protected override TilemapTileset Read(ContentReader reader, TilemapTileset existingInstance)
         {

--- a/source/MonoGame.Extended/Tilemaps/Content/TilemapWorldReader.cs
+++ b/source/MonoGame.Extended/Tilemaps/Content/TilemapWorldReader.cs
@@ -9,6 +9,21 @@ namespace MonoGame.Extended.Tilemaps.Content;
 /// </summary>
 public sealed class TilemapWorldReader : ContentTypeReader<TilemapWorld>
 {
+#if !FNA && !KNI
+    /// <summary>
+    /// Registers this <see cref="ContentTypeReader"/> with the <see cref="ContentTypeReaderManager"/>
+    /// so it is resolved without reflection.
+    /// </summary>
+    /// <remarks>
+    /// Call this method once during application startup when publishing with
+    /// <c>PublishAot</c> or <c>PublishTrimmed</c>.
+    /// </remarks>
+    public static void Register() =>
+        ContentTypeReaderManager.AddTypeCreator(
+            typeof(TilemapWorldReader).AssemblyQualifiedName,
+            () => new TilemapWorldReader());
+#endif
+
     /// <inheritdoc/>
     protected override TilemapWorld Read(ContentReader reader, TilemapWorld existingInstance)
     {


### PR DESCRIPTION
## Description

MonoGame.Extended’s binary tilemap content readers rely on reflection-based reader resolution. In trimmed or NativeAOT builds, this can cause tilemaps to fail at runtime with:

`Could not find ContentTypeReader Type: MonoGame.Extended.Tilemaps.Content.TilemapReader`

This PR adds explicit registration methods following the existing `BitmapFontContentReader.Register()` pattern.

## Related Issues/Tickets

* Related to #1170 (Native AOT Compatibility)

## Changes Made

* Added `Register()` to `TilemapReader`
* Added `Register()` to `TilemapTilesetReader`
* Added `Register()` to `TilemapWorldReader`
* Used `ContentTypeReaderManager.AddTypeCreator(...)`

## Checklist

Please read and check the following items.  Pull requests will not be reviewed if all items are not checked.

* [x] I have verified that there are no existing pull requests that would overlap with this pull request.
* [x] I have verified that I am following the guidelines as outlined in this project's contribution policy.
* [x] I have verified that this pull request adheres to this project's code of conduct.
* [x] I have written a descriptive title for this pull request.
* [ ] I have provided appropriate test coverage where applicable.

I’ve verified the library builds successfully. Would maintainers prefer a dedicated test that loads minimal tilemap XNB fixtures after calling the new Register() methods, or is the implementation pattern and build validation sufficient here?