### PR TITLE
Refactoring LDtk Tilemap Handling to be Native AOT Compatible

### DIFF
--- a/source/MonoGame.Extended.Content.Pipeline/Tilemaps/LDtk/LDtkImportHelper.cs
+++ b/source/MonoGame.Extended.Content.Pipeline/Tilemaps/LDtk/LDtkImportHelper.cs
@@ -1,9 +1,9 @@
 using System.Collections.Generic;
 using System.IO;
 using System.Text.Json;
-using System.Text.Json.Serialization;
 using Microsoft.Xna.Framework.Content.Pipeline;
 using MonoGame.Extended.Tilemaps;
+using MonoGame.Extended.Tilemaps.LDtk;
 using MonoGame.Extended.Tilemaps.LDtk.Converters;
 using MonoGame.Extended.Tilemaps.LDtk.Document;
 using MonoGame.Extended.Tilemaps.Parsers;
@@ -15,13 +15,6 @@ namespace MonoGame.Extended.Content.Pipeline.Tilemaps.LDtk;
 /// </summary>
 internal static class LDtkImportHelper
 {
-    internal static readonly JsonSerializerOptions JsonOptions = new JsonSerializerOptions
-    {
-        PropertyNameCaseInsensitive = true,
-        PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
-        NumberHandling = JsonNumberHandling.AllowReadingFromString
-    };
-
     /// <summary>
     /// Loads an LDtk project, registers all asset dependencies, and converts all levels to
     /// format-agnostic <see cref="TilemapData"/>.
@@ -48,7 +41,7 @@ internal static class LDtkImportHelper
         try
         {
             string json = File.ReadAllText(filePath);
-            LDtkProject project = JsonSerializer.Deserialize<LDtkProject>(json, JsonOptions);
+            LDtkProject project = JsonSerializer.Deserialize(json, LDtkJsonSerializerContext.Default.LDtkProject);
 
             if (project == null)
             {
@@ -112,7 +105,7 @@ internal static class LDtkImportHelper
             context.AddDependency(absoluteLevelPath);
 
             string levelJson = File.ReadAllText(absoluteLevelPath);
-            LDtkLevel resolved = JsonSerializer.Deserialize<LDtkLevel>(levelJson, JsonOptions);
+            LDtkLevel resolved = JsonSerializer.Deserialize(levelJson, LDtkJsonSerializerContext.Default.LDtkLevel);
 
             if (resolved != null)
             {

--- a/source/MonoGame.Extended/Tilemaps/LDtk/Document/LDtkFieldInstance.cs
+++ b/source/MonoGame.Extended/Tilemaps/LDtk/Document/LDtkFieldInstance.cs
@@ -19,5 +19,5 @@ internal sealed class LDtkFieldInstance
     public int DefUid { get; set; }
 
     [JsonPropertyName("realEditorValues")]
-    public List<object> RealEditorValues { get; set; } = new List<object>();
+    public List<JsonElement> RealEditorValues { get; set; } = new List<JsonElement>();
 }

--- a/source/MonoGame.Extended/Tilemaps/LDtk/LDtkJsonParser.cs
+++ b/source/MonoGame.Extended/Tilemaps/LDtk/LDtkJsonParser.cs
@@ -17,13 +17,6 @@ namespace MonoGame.Extended.Tilemaps.LDtk;
 /// </summary>
 public class LDtkJsonParser : ITilemapParser
 {
-    private static readonly JsonSerializerOptions s_jsonOptions = new JsonSerializerOptions
-    {
-        PropertyNameCaseInsensitive = true,
-        PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
-        NumberHandling = System.Text.Json.Serialization.JsonNumberHandling.AllowReadingFromString
-    };
-
     private readonly string _baseDirectory;
     private readonly ExternalResourceResolver _resourceResolver;
 
@@ -121,7 +114,7 @@ public class LDtkJsonParser : ITilemapParser
 
         try
         {
-            LDtkProject project = JsonSerializer.Deserialize<LDtkProject>(stream, s_jsonOptions);
+            LDtkProject project = JsonSerializer.Deserialize(stream, LDtkJsonSerializerContext.Default.LDtkProject);
 
             if (project == null)
             {
@@ -454,7 +447,7 @@ public class LDtkJsonParser : ITilemapParser
     private LDtkProject LoadProject(string filePath)
     {
         using Stream stream = OpenProjectStream(filePath);
-        LDtkProject project = JsonSerializer.Deserialize<LDtkProject>(stream, s_jsonOptions);
+        LDtkProject project = JsonSerializer.Deserialize(stream, LDtkJsonSerializerContext.Default.LDtkProject);
 
         if (project == null)
         {
@@ -509,7 +502,7 @@ public class LDtkJsonParser : ITilemapParser
         try
         {
             using Stream stream = _resourceResolver(levelPath);
-            return JsonSerializer.Deserialize<LDtkLevel>(stream, s_jsonOptions);
+            return JsonSerializer.Deserialize(stream, LDtkJsonSerializerContext.Default.LDtkLevel);
         }
         catch (TilemapParseException)
         {

--- a/source/MonoGame.Extended/Tilemaps/LDtk/LDtkJsonSerializerContext.cs
+++ b/source/MonoGame.Extended/Tilemaps/LDtk/LDtkJsonSerializerContext.cs
@@ -1,0 +1,20 @@
+using System.Text.Json.Serialization;
+using MonoGame.Extended.Tilemaps.LDtk.Document;
+
+namespace MonoGame.Extended.Tilemaps.LDtk;
+
+/// <summary>
+/// Source-generated <see cref="System.Text.Json.JsonSerializer"/> context for LDtk documents.
+/// <para>
+/// Enables Native AOT compatibility.
+/// </para>
+/// </summary>
+[JsonSourceGenerationOptions(
+    PropertyNameCaseInsensitive = true,
+    PropertyNamingPolicy = JsonKnownNamingPolicy.CamelCase,
+    NumberHandling = JsonNumberHandling.AllowReadingFromString)]
+[JsonSerializable(typeof(LDtkProject))]
+[JsonSerializable(typeof(LDtkLevel))]
+internal partial class LDtkJsonSerializerContext : JsonSerializerContext
+{
+}


### PR DESCRIPTION
## Description

* Refactoring LDtk tilemap implementation to be Native AOT compatible.

## Related Issues/Tickets

* Closes #1173

## Changes Made

* Added `LDtkJsonSerializerContext` to be used instead of `JsonSerializerOptions`.
* Updated `LDtkImportHelper` to use the serializer context.
* Updated `LDtkJsonParser` to use the serializer context.
* Updated `LDtkFieldInstance` to define `RealEditorValues` as `List<JsonElement>`.

## Checklist

Please read and check the following items.  Pull requests will not be reviewed if all items are not checked.

* [x] I have verified that there are no existing pull requests that would overlap with this pull request.
* [x] I have verified that I am following the guidelines as outlined in this project's contribution policy
* [x] I have verified that this pull request adheres to this project's code of conduct.
* [x] I have written a descriptive title for this pull request.
* [ ] I have provided appropriate test coverage were applicable.
