### PR TITLE
Refactoring Ogmo Tilemap Handling to be Native AOT Compatible

### DIFF
--- a/source/MonoGame.Extended.Content.Pipeline/Tilemaps/Ogmo/OgmoTilemapImporter.cs
+++ b/source/MonoGame.Extended.Content.Pipeline/Tilemaps/Ogmo/OgmoTilemapImporter.cs
@@ -4,6 +4,7 @@ using System.IO;
 using System.Text.Json;
 using Microsoft.Xna.Framework.Content.Pipeline;
 using MonoGame.Extended.Tilemaps;
+using MonoGame.Extended.Tilemaps.Ogmo;
 using MonoGame.Extended.Tilemaps.Ogmo.Converters;
 using MonoGame.Extended.Tilemaps.Ogmo.Document;
 using MonoGame.Extended.Tilemaps.Parsers;
@@ -25,13 +26,6 @@ namespace MonoGame.Extended.Content.Pipeline.Tilemaps.Ogmo;
 [ContentImporter(".ogmo", DefaultProcessor = "TilemapProcessor", DisplayName = "Ogmo Tilemap Importer - MonoGame.Extended")]
 internal sealed class OgmoTilemapImporter : ContentImporter<TilemapProjectContentItem>
 {
-    private static readonly JsonSerializerOptions s_jsonOptions = new JsonSerializerOptions
-    {
-        PropertyNameCaseInsensitive = true,
-        AllowTrailingCommas = true,
-        ReadCommentHandling = JsonCommentHandling.Skip
-    };
-
     /// <inheritdoc/>
     public override TilemapProjectContentItem Import(string filePath, ContentImporterContext context)
     {
@@ -60,7 +54,7 @@ internal sealed class OgmoTilemapImporter : ContentImporter<TilemapProjectConten
         try
         {
             string json = File.ReadAllText(filePath);
-            OgmoProject project = JsonSerializer.Deserialize<OgmoProject>(json, s_jsonOptions);
+            OgmoProject project = JsonSerializer.Deserialize<OgmoProject>(json, OgmoJsonSerializerContext.Default.OgmoProject);
 
             if (project == null)
             {
@@ -193,7 +187,7 @@ internal sealed class OgmoTilemapImporter : ContentImporter<TilemapProjectConten
         try
         {
             string json = File.ReadAllText(levelFilePath);
-            return JsonSerializer.Deserialize<OgmoLevel>(json, s_jsonOptions);
+            return JsonSerializer.Deserialize<OgmoLevel>(json, OgmoJsonSerializerContext.Default.OgmoLevel);
         }
         catch (JsonException ex)
         {

--- a/source/MonoGame.Extended/Tilemaps/Ogmo/Converters/OgmoTilemapDataConverter.cs
+++ b/source/MonoGame.Extended/Tilemaps/Ogmo/Converters/OgmoTilemapDataConverter.cs
@@ -237,9 +237,9 @@ internal static class OgmoTilemapDataConverter
 
                 if (entity.Values != null)
                 {
-                    foreach (KeyValuePair<string, object> kvp in entity.Values)
+                    foreach (KeyValuePair<string, JsonElement> kvp in entity.Values)
                     {
-                        ConvertCustomValue(obj.Properties, kvp.Key, kvp.Value);
+                        ConvertJsonElement(obj.Properties, kvp.Key, kvp.Value);
                     }
                 }
 
@@ -284,9 +284,9 @@ internal static class OgmoTilemapDataConverter
 
                 if (decal.Values != null)
                 {
-                    foreach (KeyValuePair<string, object> kvp in decal.Values)
+                    foreach (KeyValuePair<string, JsonElement> kvp in decal.Values)
                     {
-                        ConvertCustomValue(obj.Properties, kvp.Key, kvp.Value);
+                        ConvertJsonElement(obj.Properties, kvp.Key, kvp.Value);
                     }
                 }
 
@@ -313,12 +313,12 @@ internal static class OgmoTilemapDataConverter
 
         if (layerData.ArrayMode == 0 && layerData.Grid != null)
         {
-            string gridJson = JsonSerializer.Serialize(layerData.Grid);
+            string gridJson = JsonSerializer.Serialize(layerData.Grid, OgmoJsonSerializerContext.Default.ListString);
             AddStringProperty(result.Properties, "Ogmo_GridValues", gridJson);
         }
         else if (layerData.ArrayMode == 1 && layerData.Grid2D != null)
         {
-            string gridJson = JsonSerializer.Serialize(layerData.Grid2D);
+            string gridJson = JsonSerializer.Serialize(layerData.Grid2D, OgmoJsonSerializerContext.Default.ListListString);
             AddStringProperty(result.Properties, "Ogmo_GridValues", gridJson);
         }
 
@@ -326,7 +326,7 @@ internal static class OgmoTilemapDataConverter
 
         if (template?.Legend != null && template.Legend.Count > 0)
         {
-            string legendJson = JsonSerializer.Serialize(template.Legend);
+            string legendJson = JsonSerializer.Serialize(template.Legend, OgmoJsonSerializerContext.Default.DictionaryStringString);
             AddStringProperty(result.Properties, "Ogmo_GridLegend", legendJson);
         }
 
@@ -347,9 +347,9 @@ internal static class OgmoTilemapDataConverter
 
         if (level.Values != null && level.Values.Count > 0)
         {
-            foreach (KeyValuePair<string, object> kvp in level.Values)
+            foreach (KeyValuePair<string, JsonElement> kvp in level.Values)
             {
-                ConvertCustomValue(data.Properties, $"Level_{kvp.Key}", kvp.Value);
+                ConvertJsonElement(data.Properties, $"Level_{kvp.Key}", kvp.Value);
             }
         }
     }
@@ -573,52 +573,14 @@ internal static class OgmoTilemapDataConverter
 
     #region Custom Value Conversion
 
-    private static void ConvertCustomValue(List<TilemapPropertyData> properties, string key, object value)
-    {
-        switch (value)
-        {
-            case null:
-                AddStringProperty(properties, key, string.Empty);
-                break;
-
-            case string str:
-                AddStringProperty(properties, key, str);
-                break;
-
-            case bool boolValue:
-                AddBoolProperty(properties, key, boolValue);
-                break;
-
-            case int intValue:
-                AddIntProperty(properties, key, intValue);
-                break;
-
-            case long longValue:
-                AddIntProperty(properties, key, (int)longValue);
-                break;
-
-            case float floatValue:
-                AddFloatProperty(properties, key, floatValue);
-                break;
-
-            case double doubleValue:
-                AddFloatProperty(properties, key, (float)doubleValue);
-                break;
-
-            case JsonElement element:
-                ConvertJsonElement(properties, key, element);
-                break;
-
-            default:
-                AddStringProperty(properties, key, value.ToString() ?? string.Empty);
-                break;
-        }
-    }
-
     private static void ConvertJsonElement(List<TilemapPropertyData> properties, string key, JsonElement element)
     {
         switch (element.ValueKind)
         {
+            case JsonValueKind.Null:
+                AddStringProperty(properties, key, string.Empty);
+                break;
+
             case JsonValueKind.True:
                 AddBoolProperty(properties, key, true);
                 break;

--- a/source/MonoGame.Extended/Tilemaps/Ogmo/Document/OgmoDecal.cs
+++ b/source/MonoGame.Extended/Tilemaps/Ogmo/Document/OgmoDecal.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+using System.Text.Json;
 using System.Text.Json.Serialization;
 
 namespace MonoGame.Extended.Tilemaps.Ogmo.Document;
@@ -24,5 +25,5 @@ internal sealed class OgmoDecal
     public float ScaleY { get; set; }
 
     [JsonPropertyName("values")]
-    public Dictionary<string, object> Values { get; set; }
+    public Dictionary<string, JsonElement> Values { get; set; }
 }

--- a/source/MonoGame.Extended/Tilemaps/Ogmo/Document/OgmoEntity.cs
+++ b/source/MonoGame.Extended/Tilemaps/Ogmo/Document/OgmoEntity.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+using System.Text.Json;
 using System.Text.Json.Serialization;
 
 namespace MonoGame.Extended.Tilemaps.Ogmo.Document;
@@ -45,5 +46,5 @@ internal sealed class OgmoEntity
     public List<OgmoVector2> Nodes { get; set; }
 
     [JsonPropertyName("values")]
-    public Dictionary<string, object> Values { get; set; }
+    public Dictionary<string, JsonElement> Values { get; set; }
 }

--- a/source/MonoGame.Extended/Tilemaps/Ogmo/Document/OgmoLevel.cs
+++ b/source/MonoGame.Extended/Tilemaps/Ogmo/Document/OgmoLevel.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+using System.Text.Json;
 using System.Text.Json.Serialization;
 
 namespace MonoGame.Extended.Tilemaps.Ogmo.Document;
@@ -21,7 +22,7 @@ internal sealed class OgmoLevel
     public float OffsetY { get; set; }
 
     [JsonPropertyName("values")]
-    public Dictionary<string, object> Values { get; set; }
+    public Dictionary<string, JsonElement> Values { get; set; }
 
     [JsonPropertyName("layers")]
     public List<OgmoLayerData> Layers { get; set; }

--- a/source/MonoGame.Extended/Tilemaps/Ogmo/Document/OgmoValueTemplate.cs
+++ b/source/MonoGame.Extended/Tilemaps/Ogmo/Document/OgmoValueTemplate.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+using System.Text.Json;
 using System.Text.Json.Serialization;
 
 namespace MonoGame.Extended.Tilemaps.Ogmo.Document;
@@ -12,7 +13,7 @@ internal sealed class OgmoValueTemplate
     public string Definition { get; set; }
 
     [JsonPropertyName("defaults")]
-    public object Defaults { get; set; }
+    public JsonElement? Defaults { get; set; }
 
     [JsonPropertyName("bounded")]
     public bool Bounded { get; set; }

--- a/source/MonoGame.Extended/Tilemaps/Ogmo/OgmoJsonParser.cs
+++ b/source/MonoGame.Extended/Tilemaps/Ogmo/OgmoJsonParser.cs
@@ -16,13 +16,6 @@ namespace MonoGame.Extended.Tilemaps.Ogmo;
 /// </summary>
 public sealed class OgmoJsonParser : ITilemapParser
 {
-    private static readonly JsonSerializerOptions s_jsonOptions = new JsonSerializerOptions
-    {
-        PropertyNameCaseInsensitive = true,
-        AllowTrailingCommas = true,
-        ReadCommentHandling = JsonCommentHandling.Skip
-    };
-
     private readonly string _projectPath;
     private readonly string _baseDirectory;
     private readonly ExternalResourceResolver _resourceResolver;
@@ -128,7 +121,7 @@ public sealed class OgmoJsonParser : ITilemapParser
 
         try
         {
-            OgmoLevel level = JsonSerializer.Deserialize<OgmoLevel>(stream, s_jsonOptions);
+            OgmoLevel level = JsonSerializer.Deserialize(stream, OgmoJsonSerializerContext.Default.OgmoLevel);
 
             if (level == null)
             {
@@ -160,7 +153,7 @@ public sealed class OgmoJsonParser : ITilemapParser
         try
         {
             using Stream stream = OpenProjectStream(projectPath);
-            OgmoProject project = JsonSerializer.Deserialize<OgmoProject>(stream, s_jsonOptions);
+            OgmoProject project = JsonSerializer.Deserialize(stream, OgmoJsonSerializerContext.Default.OgmoProject);
 
             if (project == null)
             {
@@ -178,7 +171,7 @@ public sealed class OgmoJsonParser : ITilemapParser
     private OgmoLevel LoadLevel(string levelPath)
     {
         using Stream stream = OpenLevelStream(levelPath);
-        OgmoLevel level = JsonSerializer.Deserialize<OgmoLevel>(stream, s_jsonOptions);
+        OgmoLevel level = JsonSerializer.Deserialize(stream, OgmoJsonSerializerContext.Default.OgmoLevel);
 
         if (level == null)
         {

--- a/source/MonoGame.Extended/Tilemaps/Ogmo/OgmoJsonSerializerContext.cs
+++ b/source/MonoGame.Extended/Tilemaps/Ogmo/OgmoJsonSerializerContext.cs
@@ -1,0 +1,28 @@
+using System.Collections.Generic;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using MonoGame.Extended.Tilemaps.Ogmo.Document;
+
+namespace MonoGame.Extended.Tilemaps.Ogmo;
+
+/// <summary>
+/// Source-generated <see cref="System.Text.Json.JsonSerializer"/> context for Ogmo documents.
+/// <para>
+/// Enables Native AOT compatibility.
+/// </para>
+/// </summary>
+[JsonSourceGenerationOptions(
+    PropertyNameCaseInsensitive = true,
+    AllowTrailingCommas = true,
+    ReadCommentHandling = JsonCommentHandling.Skip)]
+[JsonSerializable(typeof(OgmoProject))]
+[JsonSerializable(typeof(OgmoLevel))]
+[JsonSerializable(typeof(OgmoTileLayerData))]
+[JsonSerializable(typeof(OgmoGridLayerData))]
+[JsonSerializable(typeof(OgmoEntityLayerData))]
+[JsonSerializable(typeof(OgmoDecalLayerData))]
+[JsonSerializable(typeof(OgmoLayerData))]
+[JsonSerializable(typeof(List<string>))]
+[JsonSerializable(typeof(List<List<string>>))]
+[JsonSerializable(typeof(Dictionary<string, string>))]
+internal partial class OgmoJsonSerializerContext : JsonSerializerContext { }

--- a/source/MonoGame.Extended/Tilemaps/Ogmo/OgmoLayerDataConverter.cs
+++ b/source/MonoGame.Extended/Tilemaps/Ogmo/OgmoLayerDataConverter.cs
@@ -16,47 +16,109 @@ internal sealed class OgmoLayerDataConverter : JsonConverter<OgmoLayerData>
             root.TryGetProperty("data", out _) ||
             root.TryGetProperty("data2D", out _))
         {
-            return JsonSerializer.Deserialize<OgmoTileLayerData>(root.GetRawText(), options);
+            return JsonSerializer.Deserialize(root.GetRawText(), OgmoJsonSerializerContext.Default.OgmoTileLayerData);
         }
         else if (root.TryGetProperty("grid", out _) ||
                  root.TryGetProperty("grid2D", out _))
         {
-            return JsonSerializer.Deserialize<OgmoGridLayerData>(root.GetRawText(), options);
+            return JsonSerializer.Deserialize(root.GetRawText(), OgmoJsonSerializerContext.Default.OgmoGridLayerData);
         }
         else if (root.TryGetProperty("entities", out _))
         {
-            return JsonSerializer.Deserialize<OgmoEntityLayerData>(root.GetRawText(), options);
+            return JsonSerializer.Deserialize(root.GetRawText(), OgmoJsonSerializerContext.Default.OgmoEntityLayerData);
         }
         else if (root.TryGetProperty("decals", out _))
         {
-            return JsonSerializer.Deserialize<OgmoDecalLayerData>(root.GetRawText(), options);
+            return JsonSerializer.Deserialize(root.GetRawText(), OgmoJsonSerializerContext.Default.OgmoDecalLayerData);
         }
 
-        // If we can't determine the type, return base layer data
-        return JsonSerializer.Deserialize<OgmoLayerData>(root.GetRawText(), options);
+        #region Fallback Read
+
+        // If we can't determine the type, return base layer data.
+        // Manually construct base OgmoLayerData to avoid StackOverflowException.
+        OgmoLayerData fallback = new();
+        
+        if (root.TryGetProperty("name", out JsonElement nameElement))
+        {
+            fallback.Name = nameElement.GetString();
+        }
+        if (root.TryGetProperty("_eid", out JsonElement eidElement))
+        {
+            fallback.ExportID = eidElement.GetString();
+        }
+        if (root.TryGetProperty("offsetX", out JsonElement offsetXElement)
+            && offsetXElement.TryGetSingle(out float offsetX))
+        {
+            fallback.OffsetX = offsetX;
+        }
+        if (root.TryGetProperty("offsetY", out JsonElement offsetYElement)
+            && offsetYElement.TryGetSingle(out float offsetY))
+        {
+            fallback.OffsetY = offsetY;
+        }
+        if (root.TryGetProperty("gridCellWidth", out JsonElement gridCellWidthElement)
+            && gridCellWidthElement.TryGetInt32(out int gridCellWidth))
+        {
+            fallback.GridCellWidth = gridCellWidth;
+        }
+        if (root.TryGetProperty("gridCellHeight", out JsonElement gridCellHeightElement)
+            && gridCellHeightElement.TryGetInt32(out int gridCellHeight))
+        {
+            fallback.GridCellHeight = gridCellHeight;
+        }
+        if (root.TryGetProperty("gridCellsX", out JsonElement gridCellsXElement)
+            && gridCellsXElement.TryGetInt32(out int gridCellsX))
+        {
+            fallback.GridCellsX = gridCellsX;
+        }
+        if (root.TryGetProperty("gridCellsY", out JsonElement gridCellsYElement)
+            && gridCellsYElement.TryGetInt32(out int gridCellsY))
+        {
+            fallback.GridCellsY = gridCellsY;
+        }
+        
+        return fallback;
+
+        #endregion Fallback Read
     }
 
     public override void Write(Utf8JsonWriter writer, OgmoLayerData value, JsonSerializerOptions options)
     {
         if (value is OgmoTileLayerData tileLayer)
         {
-            JsonSerializer.Serialize(writer, tileLayer, options);
+            JsonSerializer.Serialize(writer, tileLayer, OgmoJsonSerializerContext.Default.OgmoTileLayerData);
         }
         else if (value is OgmoGridLayerData gridLayer)
         {
-            JsonSerializer.Serialize(writer, gridLayer, options);
+            JsonSerializer.Serialize(writer, gridLayer, OgmoJsonSerializerContext.Default.OgmoGridLayerData);
         }
         else if (value is OgmoEntityLayerData entityLayer)
         {
-            JsonSerializer.Serialize(writer, entityLayer, options);
+            JsonSerializer.Serialize(writer, entityLayer, OgmoJsonSerializerContext.Default.OgmoEntityLayerData);
         }
         else if (value is OgmoDecalLayerData decalLayer)
         {
-            JsonSerializer.Serialize(writer, decalLayer, options);
+            JsonSerializer.Serialize(writer, decalLayer, OgmoJsonSerializerContext.Default.OgmoDecalLayerData);
         }
         else
         {
-            JsonSerializer.Serialize(writer, value, options);
+            #region Fallback Write
+            
+            // Fallback: Manually write base OgmoLayerData to avoid StackOverflowException.
+            writer.WriteStartObject();
+            
+            writer.WriteString("name", value.Name);
+            writer.WriteString("_eid", value.ExportID);
+            writer.WriteNumber("offsetX", value.OffsetX);
+            writer.WriteNumber("offsetY", value.OffsetY);
+            writer.WriteNumber("gridCellWidth", value.GridCellWidth);
+            writer.WriteNumber("gridCellHeight", value.GridCellHeight);
+            writer.WriteNumber("gridCellsX", value.GridCellsX);
+            writer.WriteNumber("gridCellsY", value.GridCellsY);
+            
+            writer.WriteEndObject();
+
+            #endregion Fallback Write
         }
     }
 }


### PR DESCRIPTION
## Description

* Refactoring Ogmo tilemap implementation to be Native AOT compatible.

## Related Issues/Tickets

* Closes #1174

## Changes Made

* Added `OgmoJsonSerializerContext`.
* Updated `OgmoJsonParser` to use the context.
* Updated `OgmoTilemapImporter` to use the context.
* Updated `OgmoLayerDataConverter` to use the context.
* Updated internal models to use `Dictionary<string, JsonElement>`:
   1. `OgmoDecal`
   2. `OgmoEntity`
   3. `OgmoLevel`
   4. `OgmoValueTemplate`
* Updated `OgmoTilemapDataConverter` to use the context and the updated models.

## Checklist

Please read and check the following items.  Pull requests will not be reviewed if all items are not checked.

* [x] I have verified that there are no existing pull requests that would overlap with this pull request.
* [x] I have verified that I am following the guidelines as outlined in this project's contribution policy
* [x] I have verified that this pull request adheres to this project's code of conduct.
* [x] I have written a descriptive title for this pull request.
* [ ] I have provided appropriate test coverage were applicable.
