### PR TITLE
Fixing Native AOT Registration for Tilemaps

### DIFF
--- a/source/MonoGame.Extended.Content.Pipeline/Tilemaps/Tiled/TilemapTilesetWriter.cs
+++ b/source/MonoGame.Extended.Content.Pipeline/Tilemaps/Tiled/TilemapTilesetWriter.cs
@@ -3,6 +3,7 @@ using Microsoft.Xna.Framework.Content.Pipeline;
 using Microsoft.Xna.Framework.Content.Pipeline.Graphics;
 using Microsoft.Xna.Framework.Content.Pipeline.Serialization.Compiler;
 using MonoGame.Extended.Tilemaps;
+using MonoGame.Extended.Tilemaps.Content;
 
 namespace MonoGame.Extended.Content.Pipeline.Tilemaps.Tiled;
 
@@ -55,6 +56,6 @@ public sealed class TilemapTilesetWriter : ContentTypeWriter<TilemapTilesetConte
     /// <inheritdoc/>
     public override string GetRuntimeReader(TargetPlatform targetPlatform)
     {
-        return "MonoGame.Extended.Tilemaps.Content.TilemapTilesetReader, MonoGame.Extended";
+        return TilemapTilesetReader.NativeAotRegistrationKey;
     }
 }

--- a/source/MonoGame.Extended.Content.Pipeline/Tilemaps/TilemapWorldWriter.cs
+++ b/source/MonoGame.Extended.Content.Pipeline/Tilemaps/TilemapWorldWriter.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using Microsoft.Xna.Framework.Content.Pipeline;
 using Microsoft.Xna.Framework.Content.Pipeline.Serialization.Compiler;
 using MonoGame.Extended.Tilemaps;
+using MonoGame.Extended.Tilemaps.Content;
 
 namespace MonoGame.Extended.Content.Pipeline.Tilemaps;
 
@@ -39,6 +40,6 @@ internal sealed class TilemapWorldWriter : ContentTypeWriter<TilemapWorldContent
     /// <inheritdoc/>
     public override string GetRuntimeReader(TargetPlatform targetPlatform)
     {
-        return "MonoGame.Extended.Tilemaps.Content.TilemapWorldReader, MonoGame.Extended";
+        return TilemapWorldReader.NativeAotRegistrationKey;
     }
 }

--- a/source/MonoGame.Extended.Content.Pipeline/Tilemaps/TilemapWriter.cs
+++ b/source/MonoGame.Extended.Content.Pipeline/Tilemaps/TilemapWriter.cs
@@ -2,6 +2,7 @@ using System;
 using Microsoft.Xna.Framework.Content.Pipeline;
 using Microsoft.Xna.Framework.Content.Pipeline.Serialization.Compiler;
 using MonoGame.Extended.Tilemaps;
+using MonoGame.Extended.Tilemaps.Content;
 
 namespace MonoGame.Extended.Content.Pipeline.Tilemaps;
 
@@ -30,6 +31,6 @@ public sealed class TilemapWriter : ContentTypeWriter<TilemapContentItem>
     /// <inheritdoc/>
     public override string GetRuntimeReader(TargetPlatform targetPlatform)
     {
-        return "MonoGame.Extended.Tilemaps.Content.TilemapReader, MonoGame.Extended";
+        return TilemapReader.NativeAotRegistrationKey;
     }
 }

--- a/source/MonoGame.Extended/Tilemaps/Content/TilemapReader.cs
+++ b/source/MonoGame.Extended/Tilemaps/Content/TilemapReader.cs
@@ -8,10 +8,10 @@ namespace MonoGame.Extended.Tilemaps.Content;
 /// </summary>
 public sealed class TilemapReader : ContentTypeReader<Tilemap>
 {
-#if !FNA && !KNI
     internal static readonly string NativeAotRegistrationKey =
         "MonoGame.Extended.Tilemaps.Content.TilemapReader, MonoGame.Extended";
 
+#if !FNA && !KNI
     /// <summary>
     /// Registers this <see cref="ContentTypeReader"/> with the <see cref="ContentTypeReaderManager"/>
     /// so it is resolved without reflection.

--- a/source/MonoGame.Extended/Tilemaps/Content/TilemapReader.cs
+++ b/source/MonoGame.Extended/Tilemaps/Content/TilemapReader.cs
@@ -9,7 +9,7 @@ namespace MonoGame.Extended.Tilemaps.Content;
 public sealed class TilemapReader : ContentTypeReader<Tilemap>
 {
     internal static readonly string NativeAotRegistrationKey =
-        "MonoGame.Extended.Tilemaps.Content.TilemapReader, MonoGame.Extended";
+        $"{typeof(TilemapReader).FullName}, {typeof(TilemapReader).Assembly.GetName().Name}";
 
 #if !FNA && !KNI
     /// <summary>

--- a/source/MonoGame.Extended/Tilemaps/Content/TilemapReader.cs
+++ b/source/MonoGame.Extended/Tilemaps/Content/TilemapReader.cs
@@ -9,6 +9,9 @@ namespace MonoGame.Extended.Tilemaps.Content;
 public sealed class TilemapReader : ContentTypeReader<Tilemap>
 {
 #if !FNA && !KNI
+    internal static readonly string NativeAotRegistrationKey =
+        "MonoGame.Extended.Tilemaps.Content.TilemapReader, MonoGame.Extended";
+
     /// <summary>
     /// Registers this <see cref="ContentTypeReader"/> with the <see cref="ContentTypeReaderManager"/>
     /// so it is resolved without reflection.
@@ -19,7 +22,7 @@ public sealed class TilemapReader : ContentTypeReader<Tilemap>
     /// </remarks>
     public static void Register() =>
         ContentTypeReaderManager.AddTypeCreator(
-            typeof(TilemapReader).AssemblyQualifiedName,
+            NativeAotRegistrationKey,
             () => new TilemapReader());
 #endif
 

--- a/source/MonoGame.Extended/Tilemaps/Content/TilemapTilesetReader.cs
+++ b/source/MonoGame.Extended/Tilemaps/Content/TilemapTilesetReader.cs
@@ -12,6 +12,9 @@ namespace MonoGame.Extended.Tilemaps.Content
     public sealed class TilemapTilesetReader : ContentTypeReader<TilemapTileset>
     {
 #if !FNA && !KNI
+        internal static readonly string NativeAotRegistrationKey =
+            "MonoGame.Extended.Tilemaps.Content.TilemapTilesetReader, MonoGame.Extended";
+
         /// <summary>
         /// Registers this <see cref="ContentTypeReader"/> with the <see cref="ContentTypeReaderManager"/>
         /// so it is resolved without reflection.
@@ -22,7 +25,7 @@ namespace MonoGame.Extended.Tilemaps.Content
         /// </remarks>
         public static void Register() =>
             ContentTypeReaderManager.AddTypeCreator(
-                typeof(TilemapTilesetReader).AssemblyQualifiedName,
+                NativeAotRegistrationKey,
                 () => new TilemapTilesetReader());
 #endif
 

--- a/source/MonoGame.Extended/Tilemaps/Content/TilemapTilesetReader.cs
+++ b/source/MonoGame.Extended/Tilemaps/Content/TilemapTilesetReader.cs
@@ -12,7 +12,7 @@ namespace MonoGame.Extended.Tilemaps.Content
     public sealed class TilemapTilesetReader : ContentTypeReader<TilemapTileset>
     {
         internal static readonly string NativeAotRegistrationKey =
-            "MonoGame.Extended.Tilemaps.Content.TilemapTilesetReader, MonoGame.Extended";
+            $"{typeof(TilemapTilesetReader).FullName}, {typeof(TilemapTilesetReader).Assembly.GetName().Name}";
 
 #if !FNA && !KNI
         /// <summary>

--- a/source/MonoGame.Extended/Tilemaps/Content/TilemapTilesetReader.cs
+++ b/source/MonoGame.Extended/Tilemaps/Content/TilemapTilesetReader.cs
@@ -11,10 +11,10 @@ namespace MonoGame.Extended.Tilemaps.Content
     /// </summary>
     public sealed class TilemapTilesetReader : ContentTypeReader<TilemapTileset>
     {
-#if !FNA && !KNI
         internal static readonly string NativeAotRegistrationKey =
             "MonoGame.Extended.Tilemaps.Content.TilemapTilesetReader, MonoGame.Extended";
 
+#if !FNA && !KNI
         /// <summary>
         /// Registers this <see cref="ContentTypeReader"/> with the <see cref="ContentTypeReaderManager"/>
         /// so it is resolved without reflection.

--- a/source/MonoGame.Extended/Tilemaps/Content/TilemapWorldReader.cs
+++ b/source/MonoGame.Extended/Tilemaps/Content/TilemapWorldReader.cs
@@ -10,7 +10,7 @@ namespace MonoGame.Extended.Tilemaps.Content;
 public sealed class TilemapWorldReader : ContentTypeReader<TilemapWorld>
 {
     internal static readonly string NativeAotRegistrationKey =
-        "MonoGame.Extended.Tilemaps.Content.TilemapWorldReader, MonoGame.Extended";
+        $"{typeof(TilemapWorldReader).FullName}, {typeof(TilemapWorldReader).Assembly.GetName().Name}";
 
 #if !FNA && !KNI
     /// <summary>

--- a/source/MonoGame.Extended/Tilemaps/Content/TilemapWorldReader.cs
+++ b/source/MonoGame.Extended/Tilemaps/Content/TilemapWorldReader.cs
@@ -10,6 +10,9 @@ namespace MonoGame.Extended.Tilemaps.Content;
 public sealed class TilemapWorldReader : ContentTypeReader<TilemapWorld>
 {
 #if !FNA && !KNI
+    internal static readonly string NativeAotRegistrationKey =
+        "MonoGame.Extended.Tilemaps.Content.TilemapWorldReader, MonoGame.Extended";
+
     /// <summary>
     /// Registers this <see cref="ContentTypeReader"/> with the <see cref="ContentTypeReaderManager"/>
     /// so it is resolved without reflection.
@@ -20,7 +23,7 @@ public sealed class TilemapWorldReader : ContentTypeReader<TilemapWorld>
     /// </remarks>
     public static void Register() =>
         ContentTypeReaderManager.AddTypeCreator(
-            typeof(TilemapWorldReader).AssemblyQualifiedName,
+            NativeAotRegistrationKey,
             () => new TilemapWorldReader());
 #endif
 

--- a/source/MonoGame.Extended/Tilemaps/Content/TilemapWorldReader.cs
+++ b/source/MonoGame.Extended/Tilemaps/Content/TilemapWorldReader.cs
@@ -9,10 +9,10 @@ namespace MonoGame.Extended.Tilemaps.Content;
 /// </summary>
 public sealed class TilemapWorldReader : ContentTypeReader<TilemapWorld>
 {
-#if !FNA && !KNI
     internal static readonly string NativeAotRegistrationKey =
         "MonoGame.Extended.Tilemaps.Content.TilemapWorldReader, MonoGame.Extended";
 
+#if !FNA && !KNI
     /// <summary>
     /// Registers this <see cref="ContentTypeReader"/> with the <see cref="ContentTypeReaderManager"/>
     /// so it is resolved without reflection.


### PR DESCRIPTION
## Description

* Fixing type registration for tilemap readers.

## Related Issues/Tickets

* Closes #1192

## Changes Made

* Updated tilemap readers to register themselves with the correct short type strings:
   * `TilemapReader`
   * `TilemapTilesetReader`
   * `TilemapWorldReader`
* Updated tilemap writers to use the magic strings from the readers, to avoid duplication:
   * `TilemapWriter`
   * `TilemapTilesetWriter`
   * `TilemapWorldWriter`

## Checklist

Please read and check the following items.  Pull requests will not be reviewed if all items are not checked.

* [x] I have verified that there are no existing pull requests that would overlap with this pull request.
* [x] I have verified that I am following the guidelines as outlined in this project's contribution policy
* [x] I have verified that this pull request adheres to this project's code of conduct.
* [x] I have written a descriptive title for this pull request.
* [ ] I have provided appropriate test coverage were applicable.
