### PR TITLE
Refactoring Json Serialization to be Native AOT Compatible

### DIFF
--- a/source/MonoGame.Extended/Content/ContentReaders/JsonContentTypeReader.cs
+++ b/source/MonoGame.Extended/Content/ContentReaders/JsonContentTypeReader.cs
@@ -1,12 +1,29 @@
+using System;
+using System.Diagnostics.CodeAnalysis;
 using System.IO;
 using System.Text.Json;
+using System.Text.Json.Serialization.Metadata;
 using Microsoft.Xna.Framework.Content;
-
 
 namespace MonoGame.Extended.Content.ContentReaders
 {
     public class JsonContentTypeReader<T> : ContentTypeReader<T>
     {
+        internal static readonly string NativeAotRegistrationKey =
+            $"{typeof(JsonContentTypeReader<T>).FullName}, {typeof(JsonContentTypeReader<T>).Assembly.GetName().Name}";
+
+        private readonly JsonTypeInfo<T>? _jsonTypeInfo;
+
+        public JsonContentTypeReader()
+        {
+        }
+
+        public JsonContentTypeReader(JsonTypeInfo<T> jsonTypeInfo)
+        {
+            ArgumentNullException.ThrowIfNull(jsonTypeInfo);
+            _jsonTypeInfo = jsonTypeInfo;
+        }
+
 #if !FNA && !KNI
         /// <summary>
         /// Registers <see cref="JsonContentTypeReader{T}"/> for the type <typeparamref name="T"/> with the
@@ -14,21 +31,58 @@ namespace MonoGame.Extended.Content.ContentReaders
         /// </summary>
         /// <remarks>
         /// Call this method once per concrete type during application startup when publishing with
-        /// <c>PublishAot</c> or <c>PublishTrimmed</c>. For example:
-        /// <code>
-        /// JsonContentTypeReader&lt;MyData&gt;.Register();
-        /// </code>
+        /// <c>PublishAot</c> or <c>PublishTrimmed</c>.
         /// </remarks>
-        public static void Register() =>
+        [Obsolete("Use Register(JsonTypeInfo<T> jsonTypeInfo) overload for Native AOT compatibility.")]
+        public static void Register()
+        {
+            // Preferred registration.
+            ContentTypeReaderManager.AddTypeCreator(
+                NativeAotRegistrationKey,
+                () => new JsonContentTypeReader<T>());
+
+            // Backwards compatibility.
             ContentTypeReaderManager.AddTypeCreator(
                 typeof(JsonContentTypeReader<T>).AssemblyQualifiedName,
                 () => new JsonContentTypeReader<T>());
+        }
+
+        /// <summary>
+        /// Registers <see cref="JsonContentTypeReader{T}"/> for the type <typeparamref name="T"/> with the
+        /// <see cref="ContentTypeReaderManager"/> using source-generated type metadata for Native AOT compatibility.
+        /// </summary>
+        /// <param name="jsonTypeInfo">The source-generated type metadata for <typeparamref name="T"/>.</param>
+        public static void Register(JsonTypeInfo<T> jsonTypeInfo)
+        {
+            ArgumentNullException.ThrowIfNull(jsonTypeInfo);
+
+            // Preferred registration.
+            ContentTypeReaderManager.AddTypeCreator(
+                NativeAotRegistrationKey,
+                () => new JsonContentTypeReader<T>(jsonTypeInfo));
+
+            // Backwards compatibility.
+            ContentTypeReaderManager.AddTypeCreator(
+                typeof(JsonContentTypeReader<T>).AssemblyQualifiedName,
+                () => new JsonContentTypeReader<T>(jsonTypeInfo));
+        }
 #endif
 
         protected override T Read(ContentReader reader, T existingInstance)
         {
             var json = reader.ReadString();
-            return JsonSerializer.Deserialize<T>(json);
+
+            return _jsonTypeInfo != null
+                ? JsonSerializer.Deserialize(json, _jsonTypeInfo)
+                : LegacyDeserialize(json);
         }
+
+        [UnconditionalSuppressMessage("AOT",
+            "IL3050:RequiresDynamicCode",
+            Justification = "Fallback for JIT scenarios when registered without JsonTypeInfo.")]
+        [UnconditionalSuppressMessage("Trimming",
+            "IL2026:RequiresUnreferencedCode",
+            Justification = "Fallback for JIT scenarios when registered without JsonTypeInfo.")]
+        private static T? LegacyDeserialize(string json) => JsonSerializer.Deserialize<T>(json)!;
     }
 }

--- a/source/MonoGame.Extended/Content/ContentReaders/JsonContentTypeReader.cs
+++ b/source/MonoGame.Extended/Content/ContentReaders/JsonContentTypeReader.cs
@@ -83,6 +83,6 @@ namespace MonoGame.Extended.Content.ContentReaders
         [UnconditionalSuppressMessage("Trimming",
             "IL2026:RequiresUnreferencedCode",
             Justification = "Fallback for JIT scenarios when registered without JsonTypeInfo.")]
-        private static T? LegacyDeserialize(string json) => JsonSerializer.Deserialize<T>(json)!;
+        private static T? LegacyDeserialize(string json) => JsonSerializer.Deserialize<T>(json);
     }
 }

--- a/source/MonoGame.Extended/Content/TexturePacker/TexturePackerFileReader.cs
+++ b/source/MonoGame.Extended/Content/TexturePacker/TexturePackerFileReader.cs
@@ -18,6 +18,6 @@ internal static class TexturePackerFileReader
     internal static TexturePackerFileContent Read(Stream stream)
     {
         var tpFile = JsonSerializer.Deserialize(stream, TexturePackerJsonSerializerContext.Default.TexturePackerFileContent);
-        return tpFile!;
+        return tpFile;
     }
 }

--- a/source/MonoGame.Extended/Content/TexturePacker/TexturePackerFileReader.cs
+++ b/source/MonoGame.Extended/Content/TexturePacker/TexturePackerFileReader.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Craftwork Games. All rights reserved.
+// Copyright (c) Craftwork Games. All rights reserved.
 // Licensed under the MIT license.
 // See LICENSE file in the project root for full license information.
 
@@ -17,7 +17,7 @@ internal static class TexturePackerFileReader
 
     internal static TexturePackerFileContent Read(Stream stream)
     {
-        var tpFile = JsonSerializer.Deserialize<TexturePackerFileContent>(stream);
-        return tpFile;
+        var tpFile = JsonSerializer.Deserialize(stream, TexturePackerJsonSerializerContext.Default.TexturePackerFileContent);
+        return tpFile!;
     }
 }

--- a/source/MonoGame.Extended/Content/TexturePacker/TexturePackerJsonSerializerContext.cs
+++ b/source/MonoGame.Extended/Content/TexturePacker/TexturePackerJsonSerializerContext.cs
@@ -1,0 +1,14 @@
+using System.Text.Json.Serialization;
+
+namespace MonoGame.Extended.Content.TexturePacker;
+
+/// <summary>
+/// Source-generated <see cref="System.Text.Json.JsonSerializer"/> context for TexturePacker.
+/// <para>
+/// Provides Native AOT compatibility.
+/// </para>
+/// </summary>
+[JsonSerializable(typeof(TexturePackerFileContent))]
+internal partial class TexturePackerJsonSerializerContext : JsonSerializerContext
+{
+}

--- a/source/MonoGame.Extended/KNI.Extended.csproj
+++ b/source/MonoGame.Extended/KNI.Extended.csproj
@@ -4,6 +4,7 @@
         <DefineConstants>$(DefineConstants);KNI</DefineConstants>
         <Description>It makes KNI more awesome.</Description>
         <PackageTags>kni extended pipeline bmfont tiled texture atlas input viewport fps shapes sprite</PackageTags>
+        <IsAotCompatible>true</IsAotCompatible>
     </PropertyGroup>
 
     <ItemGroup>

--- a/source/MonoGame.Extended/Serialization/Json/BaseTypeJsonConverter.cs
+++ b/source/MonoGame.Extended/Serialization/Json/BaseTypeJsonConverter.cs
@@ -1,5 +1,6 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Reflection;
 using System.Text.Json;
@@ -7,6 +8,9 @@ using System.Text.Json.Serialization;
 
 namespace MonoGame.Extended.Serialization.Json
 {
+    [RequiresUnreferencedCode($"{nameof(BaseTypeJsonConverter<T>)} uses reflection to inspect types and properties and is not compatible with Native AOT.")]
+    [RequiresDynamicCode($"{nameof(BaseTypeJsonConverter<T>)} requires dynamic code generation for polymorphic serialization and is not compatible with Native AOT.")]
+    [Obsolete($"{nameof(BaseTypeJsonConverter<T>)} is deprecated. Use System.Text.Json polymorphic type discrimination ([JsonPolymorphic], [JsonDerivedType]) instead.")]
     public abstract class BaseTypeJsonConverter<T> : JsonConverter<T>
     {
         private readonly string _suffix;
@@ -36,6 +40,8 @@ namespace MonoGame.Extended.Serialization.Json
 
         /// <inheritdoc />
         /// <exception cref="InvalidOperationException" />
+        [UnconditionalSuppressMessage("AOT", "IL3050:RequiresDynamicCode", Justification = "Class is annotated with RequiresDynamicCode.")]
+        [UnconditionalSuppressMessage("Trimming", "IL2026:RequiresUnreferencedCode", Justification = "Class is annotated with RequiresUnreferencedCode.")]
         public override T Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
         {
             using (JsonDocument doc = JsonDocument.ParseValue(ref reader))
@@ -57,6 +63,8 @@ namespace MonoGame.Extended.Serialization.Json
         /// <exception cref="ArgumentNullException">
         /// Throw if <paramref name="writer"/> is <see langword="null"/>.
         /// </exception>
+        [UnconditionalSuppressMessage("AOT", "IL3050:RequiresDynamicCode", Justification = "Class is annotated with RequiresDynamicCode.")]
+        [UnconditionalSuppressMessage("Trimming", "IL2026:RequiresUnreferencedCode", Justification = "Class is annotated with RequiresUnreferencedCode.")]
         public override void Write(Utf8JsonWriter writer, T value, JsonSerializerOptions options)
         {
             var type = value.GetType();

--- a/source/MonoGame.Extended/Serialization/Json/ExtendedJsonSerializerContext.cs
+++ b/source/MonoGame.Extended/Serialization/Json/ExtendedJsonSerializerContext.cs
@@ -29,6 +29,7 @@ namespace MonoGame.Extended.Serialization.Json;
     })]
 #region MonoGame Framework Types with custom converters
 [JsonSerializable(typeof(Color))]
+[JsonSerializable(typeof(Point))]
 [JsonSerializable(typeof(Vector2))]
 #endregion MonoGame Framework Types with custom converters
 #region MonoGame.Extended Types
@@ -41,6 +42,7 @@ namespace MonoGame.Extended.Serialization.Json;
 [JsonSerializable(typeof(Interval<float>))]
 [JsonSerializable(typeof(Interval<HslColor>))]
 [JsonSerializable(typeof(Texture2DAtlas))]
+[JsonSerializable(typeof(Texture2DRegion))]
 #endregion MonoGame.Extended Types
 #region Primitive types
 [JsonSerializable(typeof(int))]

--- a/source/MonoGame.Extended/Serialization/Json/ExtendedJsonSerializerContext.cs
+++ b/source/MonoGame.Extended/Serialization/Json/ExtendedJsonSerializerContext.cs
@@ -1,0 +1,49 @@
+using System.Text.Json.Serialization;
+using Microsoft.Xna.Framework;
+
+namespace MonoGame.Extended.Serialization.Json;
+
+/// <summary>
+/// Source-generated <see cref="System.Text.Json.JsonSerializer"/> context for common MonoGame or MonoGame.Extended data structures.
+/// <para>
+/// Provides Native AOT compatibility.
+/// </para>
+/// </summary>
+[JsonSourceGenerationOptions(
+    WriteIndented = true,
+    DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull,
+    PropertyNamingPolicy = JsonKnownNamingPolicy.CamelCase,
+    Converters = new[]
+    {
+        typeof(ColorJsonConverter),
+        typeof(HslColorJsonConverter),
+        typeof(Vector2JsonConverter),
+        typeof(RectangleFJsonConverter),
+        typeof(ThicknessJsonConverter),
+        typeof(SizeJsonConverter),
+        typeof(Size2JsonConverter),
+        typeof(IntervalJsonConverter<int>),
+        typeof(IntervalJsonConverter<float>),
+        typeof(IntervalJsonConverter<HslColor>)
+    })]
+#region MonoGame Framework Types with custom converters
+[JsonSerializable(typeof(Color))]
+[JsonSerializable(typeof(Vector2))]
+#endregion MonoGame Framework Types with custom converters
+#region MonoGame.Extended Types
+[JsonSerializable(typeof(HslColor))]
+[JsonSerializable(typeof(RectangleF))]
+[JsonSerializable(typeof(Thickness))]
+[JsonSerializable(typeof(Size))]
+[JsonSerializable(typeof(SizeF))]
+[JsonSerializable(typeof(Interval<int>))]
+[JsonSerializable(typeof(Interval<float>))]
+[JsonSerializable(typeof(Interval<HslColor>))]
+#endregion MonoGame.Extended Types
+#region Primitive types
+[JsonSerializable(typeof(int))]
+[JsonSerializable(typeof(float))]
+#endregion Primitive types
+public partial class ExtendedJsonSerializerContext : JsonSerializerContext
+{
+}

--- a/source/MonoGame.Extended/Serialization/Json/ExtendedJsonSerializerContext.cs
+++ b/source/MonoGame.Extended/Serialization/Json/ExtendedJsonSerializerContext.cs
@@ -1,5 +1,6 @@
 using System.Text.Json.Serialization;
 using Microsoft.Xna.Framework;
+using MonoGame.Extended.Graphics;
 
 namespace MonoGame.Extended.Serialization.Json;
 
@@ -39,6 +40,7 @@ namespace MonoGame.Extended.Serialization.Json;
 [JsonSerializable(typeof(Interval<int>))]
 [JsonSerializable(typeof(Interval<float>))]
 [JsonSerializable(typeof(Interval<HslColor>))]
+[JsonSerializable(typeof(Texture2DAtlas))]
 #endregion MonoGame.Extended Types
 #region Primitive types
 [JsonSerializable(typeof(int))]

--- a/source/MonoGame.Extended/Serialization/Json/IntervalJsonConverter.cs
+++ b/source/MonoGame.Extended/Serialization/Json/IntervalJsonConverter.cs
@@ -1,6 +1,8 @@
 using System;
+using System.Diagnostics.CodeAnalysis;
 using System.Text.Json;
 using System.Text.Json.Serialization;
+using System.Text.Json.Serialization.Metadata;
 
 namespace MonoGame.Extended.Serialization.Json;
 
@@ -43,8 +45,30 @@ public class IntervalJsonConverter<T> : JsonConverter<Interval<T>> where T : ICo
     {
         ArgumentNullException.ThrowIfNull(writer);
         writer.WriteStartArray();
+
+        if (options?.TypeInfoResolver != null
+            && options.GetTypeInfo(typeof(T)) is JsonTypeInfo<T> typeInfo)
+        {
+            JsonSerializer.Serialize(writer, value.Min, typeInfo);
+            JsonSerializer.Serialize(writer, value.Max, typeInfo);
+        }
+        else
+        {
+            LegacyWrite(writer, value, options);
+        }
+
+        writer.WriteEndArray();
+    }
+
+    [UnconditionalSuppressMessage("AOT",
+        "IL3050:RequiresDynamicCode",
+        Justification = "Fallback for JIT scenarios where TypeInfoResolver is not configured.")]
+    [UnconditionalSuppressMessage("Trimming",
+        "IL2026:RequiresUnreferencedCode",
+        Justification = "Fallback for JIT scenarios where TypeInfoResolver is not configured.")]
+    private static void LegacyWrite(Utf8JsonWriter writer, Interval<T> value, JsonSerializerOptions options)
+    {
         JsonSerializer.Serialize(writer, value.Min, options);
         JsonSerializer.Serialize(writer, value.Max, options);
-        writer.WriteEndArray();
     }
 }

--- a/source/MonoGame.Extended/Serialization/Json/JsonContentLoader.cs
+++ b/source/MonoGame.Extended/Serialization/Json/JsonContentLoader.cs
@@ -1,7 +1,8 @@
-﻿using System.Text.Json;
+using System;
+using System.Text.Json;
+using System.Text.Json.Serialization.Metadata;
 using Microsoft.Xna.Framework.Content;
 using MonoGame.Extended.Content;
-
 
 namespace MonoGame.Extended.Serialization.Json
 {
@@ -9,10 +10,29 @@ namespace MonoGame.Extended.Serialization.Json
     {
         public T Load<T>(ContentManager contentManager, string path)
         {
-
             using var stream = contentManager.OpenStream(path);
             var monoGameSerializerOptions = MonoGameJsonSerializerOptionsProvider.GetOptions(contentManager, path);
-            return JsonSerializer.Deserialize<T>(stream, monoGameSerializerOptions);
+            var typeInfo = (JsonTypeInfo<T>)monoGameSerializerOptions.GetTypeInfo(typeof(T));
+
+            return JsonSerializer.Deserialize(stream, typeInfo)!;
+        }
+    }
+
+    public class JsonContentLoader<T> : IContentLoader<T>
+    {
+        private readonly JsonTypeInfo<T> _typeInfo;
+
+        public JsonContentLoader(JsonTypeInfo<T> typeInfo)
+        {
+            ArgumentNullException.ThrowIfNull(typeInfo);
+            _typeInfo = typeInfo;
+        }
+
+        public T Load(ContentManager contentManager, string path)
+        {
+            using var stream = contentManager.OpenStream(path);
+
+            return JsonSerializer.Deserialize(stream, _typeInfo)!;
         }
     }
 }

--- a/source/MonoGame.Extended/Serialization/Json/JsonContentLoader.cs
+++ b/source/MonoGame.Extended/Serialization/Json/JsonContentLoader.cs
@@ -32,7 +32,7 @@ namespace MonoGame.Extended.Serialization.Json
         {
             using var stream = contentManager.OpenStream(path);
 
-            return JsonSerializer.Deserialize(stream, _typeInfo)!;
+            return JsonSerializer.Deserialize(stream, _typeInfo);
         }
     }
 }

--- a/source/MonoGame.Extended/Serialization/Json/MonoGameJsonSerializerOptionsProvider.cs
+++ b/source/MonoGame.Extended/Serialization/Json/MonoGameJsonSerializerOptionsProvider.cs
@@ -1,6 +1,8 @@
 using System.Text.Json;
 using System.Text.Json.Serialization;
+using System.Text.Json.Serialization.Metadata;
 using Microsoft.Xna.Framework.Content;
+using MonoGame.Extended.Content.TexturePacker;
 
 namespace MonoGame.Extended.Serialization.Json;
 
@@ -12,7 +14,11 @@ public static class MonoGameJsonSerializerOptionsProvider
         {
             WriteIndented = true,
             DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull,
-            PropertyNamingPolicy = JsonNamingPolicy.CamelCase
+            PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+            TypeInfoResolver = JsonTypeInfoResolver.Combine(
+                ExtendedJsonSerializerContext.Default,
+                TexturePackerJsonSerializerContext.Default
+            )
         };
 
         options.Converters.Add(new IntervalJsonConverter<int>());

--- a/source/MonoGame.Extended/Serialization/Json/TextureAtlasJsonConverter.cs
+++ b/source/MonoGame.Extended/Serialization/Json/TextureAtlasJsonConverter.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Diagnostics;
 using System.IO;
 using System.Text.Json;
 using System.Text.Json.Serialization;
@@ -39,14 +40,53 @@ namespace MonoGame.Extended.Serialization.Json
             }
             else
             {
-                var metadata = JsonSerializer.Deserialize<InlineTextureAtlas>(ref reader, options);
+                if (reader.TokenType != JsonTokenType.StartObject)
+                {
+                    throw new JsonException($"Expected {nameof(JsonTokenType.StartObject)} token");
+                }
+
+                string textureProperty = string.Empty;
+                int regionWidth = 0;
+                int regionHeight = 0;
+
+                while (reader.Read())
+                {
+                    if (reader.TokenType == JsonTokenType.EndObject)
+                    {
+                        break;
+                    }
+
+                    if (reader.TokenType == JsonTokenType.PropertyName)
+                    {
+                        var propertyName = reader.GetString();
+                        reader.Read();
+
+                        if (string.Equals(propertyName, "texture", StringComparison.OrdinalIgnoreCase))
+                        {
+                            textureProperty = reader.GetString() ?? string.Empty;
+                        }
+                        else if (string.Equals(propertyName, "regionWidth", StringComparison.OrdinalIgnoreCase))
+                        {
+                            regionWidth = reader.GetInt32();
+                        }
+                        else if (string.Equals(propertyName, "regionHeight", StringComparison.OrdinalIgnoreCase))
+                        {
+                            regionHeight = reader.GetInt32();
+                        }
+                        else
+                        {
+                            Trace.TraceWarning($"Ignoring unexpected property: {propertyName}");
+                            reader.Skip();
+                        }
+                    }
+                }
 
                 // TODO: When we get to .NET Standard 2.1 it would be more robust to use
                 // [Path.GetRelativePath](https://docs.microsoft.com/en-us/dotnet/api/system.io.path.getrelativepath?view=netstandard-2.1)
-                var textureName = Path.GetFileNameWithoutExtension(metadata.Texture);
-                var textureDirectory = Path.GetDirectoryName(metadata.Texture);
+                var textureName = Path.GetFileNameWithoutExtension(textureProperty);
+                var textureDirectory = Path.GetDirectoryName(textureProperty);
                 var directory = Path.GetDirectoryName(_path);
-                var relativePath = Path.Combine(_contentManager.RootDirectory, directory, textureDirectory, textureName);
+                var relativePath = Path.Combine(_contentManager.RootDirectory, directory ?? string.Empty, textureDirectory ?? string.Empty, textureName);
                 var resolvedAssetName = Path.GetFullPath(relativePath);
                 Texture2D texture;
                 try
@@ -55,26 +95,24 @@ namespace MonoGame.Extended.Serialization.Json
                 }
                 catch (Exception ex)
                 {
-                    if (textureDirectory == null || textureDirectory == "")
+                    Trace.TraceWarning(
+                        $"Failed to load texture with {nameof(resolvedAssetName)}: {resolvedAssetName}. Attempting to load with {nameof(textureDirectory)}: {textureDirectory} and {nameof(textureName)}: {textureName}. Exception: {ex}");
+
+                    if (string.IsNullOrEmpty(textureDirectory))
+                    {
                         texture = _contentManager.Load<Texture2D>(textureName);
+                    }
                     else
+                    {
                         texture = _contentManager.Load<Texture2D>(textureDirectory + "/" + textureName);
+                    }
                 }
-                return Texture2DAtlas.Create(resolvedAssetName, texture, metadata.RegionWidth, metadata.RegionHeight);
+                return Texture2DAtlas.Create(resolvedAssetName, texture, regionWidth, regionHeight);
             }
         }
 
         /// <inheritdoc />
         public override void Write(Utf8JsonWriter writer, Texture2DAtlas value, JsonSerializerOptions options) { }
-
-
-        // ReSharper disable once ClassNeverInstantiated.Local
-        private class InlineTextureAtlas
-        {
-            public string Texture { get; set; }
-            public int RegionWidth { get; set; }
-            public int RegionHeight { get; set; }
-        }
 
         private string GetContentPath(string relativePath)
         {

--- a/source/MonoGame.Extended/Serialization/Json/TextureAtlasJsonConverter.cs
+++ b/source/MonoGame.Extended/Serialization/Json/TextureAtlasJsonConverter.cs
@@ -81,34 +81,59 @@ namespace MonoGame.Extended.Serialization.Json
                     }
                 }
 
-                // TODO: When we get to .NET Standard 2.1 it would be more robust to use
-                // [Path.GetRelativePath](https://docs.microsoft.com/en-us/dotnet/api/system.io.path.getrelativepath?view=netstandard-2.1)
-                var textureName = Path.GetFileNameWithoutExtension(textureProperty);
-                var textureDirectory = Path.GetDirectoryName(textureProperty);
-                var directory = Path.GetDirectoryName(_path);
-                var relativePath = Path.Combine(_contentManager.RootDirectory, directory ?? string.Empty, textureDirectory ?? string.Empty, textureName);
-                var resolvedAssetName = Path.GetFullPath(relativePath);
-                Texture2D texture;
-                try
-                {
-                    texture = _contentManager.Load<Texture2D>(resolvedAssetName);
-                }
-                catch (Exception ex)
+                var (texture, assetName) = LoadTexture(textureProperty);
+
+                return Texture2DAtlas.Create(
+                    assetName,
+                    texture,
+                    regionWidth,
+                    regionHeight);
+            }
+        }
+
+        private (Texture2D Texture, string AssetName) LoadTexture(string textureProperty)
+        {
+            var textureAtlasDirectory = Path.GetDirectoryName(_path) ?? string.Empty;
+            var textureDirectory = Path.GetDirectoryName(textureProperty)?.TrimStart('/', '\\') ?? string.Empty;
+            var textureName = Path.GetFileNameWithoutExtension(textureProperty);
+
+            var rootDirectory = string.IsNullOrEmpty(_contentManager.RootDirectory)
+                ? "."
+                : _contentManager.RootDirectory;
+
+            var fullRoot = Path.GetFullPath(rootDirectory);
+            var fullTexturePath = Path.GetFullPath(Path.Combine(fullRoot, textureAtlasDirectory, textureDirectory, textureName));
+            var resolvedAssetName = Path.GetRelativePath(fullRoot, fullTexturePath).Replace('\\', '/');
+
+            (Texture2D Texture, string AssetName) result;
+
+            try
+            {
+                var texture = _contentManager.Load<Texture2D>(resolvedAssetName);
+                result = (texture, resolvedAssetName);
+            }
+            catch (Exception ex)
+            {
+                var fallbackName = string.IsNullOrEmpty(textureDirectory)
+                    ? textureName
+                    : Path.Combine(textureDirectory, textureName).Replace('\\', '/');
+
+                if (!string.Equals(resolvedAssetName, fallbackName, StringComparison.OrdinalIgnoreCase))
                 {
                     Trace.TraceWarning(
-                        $"Failed to load texture with {nameof(resolvedAssetName)}: {resolvedAssetName}. Attempting to load with {nameof(textureDirectory)}: {textureDirectory} and {nameof(textureName)}: {textureName}. Exception: {ex}");
+                        $"Failed to load texture at resolved path '{resolvedAssetName}'. Attempting fallback path '{fallbackName}'. Exception: {ex.Message}");
 
-                    if (string.IsNullOrEmpty(textureDirectory))
-                    {
-                        texture = _contentManager.Load<Texture2D>(textureName);
-                    }
-                    else
-                    {
-                        texture = _contentManager.Load<Texture2D>(textureDirectory + "/" + textureName);
-                    }
+                    var texture = _contentManager.Load<Texture2D>(fallbackName);
+                    result = (texture, fallbackName);
                 }
-                return Texture2DAtlas.Create(resolvedAssetName, texture, regionWidth, regionHeight);
+                else
+                {
+                    // Bubble up the original exception if no fallback was attempted.
+                    throw;
+                }
             }
+
+            return result;
         }
 
         /// <inheritdoc />

--- a/source/MonoGame.Extended/Serialization/Json/Utf8JsonReaderExtensions.cs
+++ b/source/MonoGame.Extended/Serialization/Json/Utf8JsonReaderExtensions.cs
@@ -75,7 +75,7 @@ public static class Utf8JsonReaderExtensions
     {
         var value = JsonSerializer.Deserialize(ref reader, typeInfo);
 
-        return [value!];
+        return [value];
     }
 
     private static T[] ReadAsJArray<T>(this ref Utf8JsonReader reader, JsonTypeInfo<T> typeInfo)
@@ -88,7 +88,7 @@ public static class Utf8JsonReaderExtensions
                 break;
             }
 
-            items.Add(JsonSerializer.Deserialize(ref reader, typeInfo)!);
+            items.Add(JsonSerializer.Deserialize(ref reader, typeInfo));
         }
 
         return [.. items];
@@ -166,7 +166,7 @@ public static class Utf8JsonReaderExtensions
                 break;
             }
 
-            items.Add(JsonSerializer.Deserialize<T>(ref reader, options)!);
+            items.Add(JsonSerializer.Deserialize<T>(ref reader, options));
         }
 
         return [.. items];

--- a/source/MonoGame.Extended/Serialization/Json/Utf8JsonReaderExtensions.cs
+++ b/source/MonoGame.Extended/Serialization/Json/Utf8JsonReaderExtensions.cs
@@ -1,7 +1,9 @@
 using System;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 using System.Text.Json;
+using System.Text.Json.Serialization.Metadata;
 
 namespace MonoGame.Extended.Serialization.Json;
 
@@ -18,6 +20,33 @@ public static class Utf8JsonReaderExtensions
     };
 
     /// <summary>
+    /// Reads a multi-dimensional JSON array and converts it to an array of the specified type using source-generated type metadata.
+    /// </summary>
+    /// <typeparam name="T">The type of the array elements.</typeparam>
+    /// <param name="reader">The <see cref="Utf8JsonReader"/> to read from.</param>
+    /// <param name="typeInfo">The metadata for the type being deserialized.</param>
+    /// <returns>An array of the specified type.</returns>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="typeInfo"/> is <see langword="null"/>.</exception>
+    /// <exception cref="NotSupportedException">Thrown when the token type is not supported.</exception>
+    public static T[] ReadAsMultiDimensional<T>(this ref Utf8JsonReader reader, JsonTypeInfo<T> typeInfo)
+    {
+        ArgumentNullException.ThrowIfNull(typeInfo);
+
+        var tokenType = reader.TokenType;
+
+        var result = tokenType switch
+        {
+            JsonTokenType.StartArray => reader.ReadAsJArray(typeInfo),
+            JsonTokenType.String => reader.ReadAsDelimitedString<T>(),
+            JsonTokenType.Number => reader.ReadAsSingleValue(typeInfo),
+            _ => throw new NotSupportedException(
+                $"{tokenType} is not currently supported in the multi-dimensional parser")
+        };
+
+        return result;
+    }
+
+    /// <summary>
     /// Reads a multi-dimensional JSON array and converts it to an array of the specified type.
     /// </summary>
     /// <typeparam name="T">The type of the array elements.</typeparam>
@@ -27,32 +56,29 @@ public static class Utf8JsonReaderExtensions
     /// <exception cref="NotSupportedException">Thrown when the token type is not supported.</exception>
     public static T[] ReadAsMultiDimensional<T>(this ref Utf8JsonReader reader, JsonSerializerOptions options)
     {
-        var tokenType = reader.TokenType;
+        T[] result;
 
-        switch (tokenType)
+        if (options?.TypeInfoResolver != null
+            && options.GetTypeInfo(typeof(T)) is JsonTypeInfo<T> typeInfo)
         {
-            case JsonTokenType.StartArray:
-                return reader.ReadAsJArray<T>(options);
-
-            case JsonTokenType.String:
-                return reader.ReadAsDelimitedString<T>();
-
-            case JsonTokenType.Number:
-                return reader.ReadAsSingleValue<T>(options);
-
-            default:
-                throw new NotSupportedException($"{tokenType} is not currently supported in the multi-dimensional parser");
+            result = reader.ReadAsMultiDimensional(typeInfo);
         }
+        else
+        {
+            result = reader.LegacyReadAsMultiDimensional<T>(options);
+        }
+
+        return result;
     }
 
-    private static T[] ReadAsSingleValue<T>(this ref Utf8JsonReader reader, JsonSerializerOptions options)
+    private static T[] ReadAsSingleValue<T>(this ref Utf8JsonReader reader, JsonTypeInfo<T> typeInfo)
     {
-        var token = JsonDocument.ParseValue(ref reader).RootElement;
-        var value = JsonSerializer.Deserialize<T>(token.GetRawText(), options);
-        return new T[] { value };
+        var value = JsonSerializer.Deserialize(ref reader, typeInfo);
+
+        return [value!];
     }
 
-    private static T[] ReadAsJArray<T>(this ref Utf8JsonReader reader, JsonSerializerOptions options)
+    private static T[] ReadAsJArray<T>(this ref Utf8JsonReader reader, JsonTypeInfo<T> typeInfo)
     {
         var items = new List<T>();
         while (reader.Read() && reader.TokenType != JsonTokenType.EndArray)
@@ -62,10 +88,10 @@ public static class Utf8JsonReaderExtensions
                 break;
             }
 
-            items.Add(JsonSerializer.Deserialize<T>(ref reader, options));
+            items.Add(JsonSerializer.Deserialize(ref reader, typeInfo)!);
         }
 
-        return items.ToArray();
+        return [.. items];
     }
 
     private static T[] ReadAsDelimitedString<T>(this ref Utf8JsonReader reader)
@@ -73,7 +99,7 @@ public static class Utf8JsonReaderExtensions
         var value = reader.GetString();
         if (string.IsNullOrEmpty(value))
         {
-            return Array.Empty<T>();
+            return [];
         }
 
         Span<string> values = value.Split(' ');
@@ -86,5 +112,63 @@ public static class Utf8JsonReaderExtensions
         }
 
         return result;
+    }
+
+    [UnconditionalSuppressMessage("AOT",
+        "IL3050:RequiresDynamicCode",
+        Justification = "Fallback for JIT scenarios where TypeInfoResolver is not configured.")]
+    [UnconditionalSuppressMessage("Trimming",
+        "IL2026:RequiresUnreferencedCode",
+        Justification = "Fallback for JIT scenarios where TypeInfoResolver is not configured.")]
+    private static T[] LegacyReadAsMultiDimensional<T>(this ref Utf8JsonReader reader, JsonSerializerOptions options)
+    {
+        var tokenType = reader.TokenType;
+
+        T[] result = tokenType switch
+        {
+            JsonTokenType.StartArray => reader.LegacyReadAsJArray<T>(options),
+            JsonTokenType.String => reader.ReadAsDelimitedString<T>(),
+            JsonTokenType.Number => reader.LegacyReadAsSingleValue<T>(options),
+            _ => throw new NotSupportedException(
+                $"{tokenType} is not currently supported in the multi-dimensional parser")
+        };
+
+        return result;
+    }
+
+    [UnconditionalSuppressMessage("AOT",
+        "IL3050:RequiresDynamicCode",
+        Justification = "Fallback for JIT scenarios where TypeInfoResolver is not configured.")]
+    [UnconditionalSuppressMessage("Trimming",
+        "IL2026:RequiresUnreferencedCode",
+        Justification = "Fallback for JIT scenarios where TypeInfoResolver is not configured.")]
+    private static T[] LegacyReadAsSingleValue<T>(this ref Utf8JsonReader reader, JsonSerializerOptions options)
+    {
+        var token = JsonDocument.ParseValue(ref reader).RootElement;
+        var value = JsonSerializer.Deserialize<T>(token.GetRawText(), options);
+
+        return [value!];
+    }
+
+    [UnconditionalSuppressMessage("AOT",
+        "IL3050:RequiresDynamicCode",
+        Justification = "Fallback for JIT scenarios where TypeInfoResolver is not configured.")]
+    [UnconditionalSuppressMessage("Trimming",
+        "IL2026:RequiresUnreferencedCode",
+        Justification = "Fallback for JIT scenarios where TypeInfoResolver is not configured.")]
+    private static T[] LegacyReadAsJArray<T>(this ref Utf8JsonReader reader, JsonSerializerOptions options)
+    {
+        var items = new List<T>();
+        while (reader.Read() && reader.TokenType != JsonTokenType.EndArray)
+        {
+            if (reader.TokenType == JsonTokenType.EndArray)
+            {
+                break;
+            }
+
+            items.Add(JsonSerializer.Deserialize<T>(ref reader, options)!);
+        }
+
+        return [.. items];
     }
 }

--- a/tests/MonoGame.Extended.Tests/Serialization/JsonSerializerTests.cs
+++ b/tests/MonoGame.Extended.Tests/Serialization/JsonSerializerTests.cs
@@ -1,0 +1,226 @@
+using System;
+using System.IO;
+using System.Text;
+using System.Text.Json;
+using Microsoft.Xna.Framework;
+using MonoGame.Extended.Content.ContentReaders;
+using MonoGame.Extended.Content.TexturePacker;
+using MonoGame.Extended.Serialization.Json;
+using Xunit;
+
+namespace MonoGame.Extended.Tests.Serialization;
+
+public sealed class JsonSerializerTests
+{
+    [Fact]
+    public void Vector2_RoundTrip_WithContext()
+    {
+        var original = new Vector2(12.5f, 34.75f);
+        var json = JsonSerializer.Serialize(original, ExtendedJsonSerializerContext.Default.Vector2);
+        var deserialized = JsonSerializer.Deserialize(json, ExtendedJsonSerializerContext.Default.Vector2);
+        Assert.Equal(original, deserialized);
+    }
+
+    [Fact]
+    public void Color_RoundTrip_WithContext()
+    {
+        var original = Color.CornflowerBlue;
+        var json = JsonSerializer.Serialize(original, ExtendedJsonSerializerContext.Default.Color);
+        var deserialized = JsonSerializer.Deserialize(json, ExtendedJsonSerializerContext.Default.Color);
+        Assert.Equal(original, deserialized);
+    }
+
+    [Fact]
+    public void HslColor_RoundTrip_WithContext()
+    {
+        var original = HslColor.FromRgb(Color.Red);
+        var json = JsonSerializer.Serialize(original, ExtendedJsonSerializerContext.Default.HslColor);
+        var deserialized = JsonSerializer.Deserialize(json, ExtendedJsonSerializerContext.Default.HslColor);
+        Assert.Equal(HslColor.ToRgb(original), HslColor.ToRgb(deserialized));
+    }
+
+    [Fact]
+    public void RectangleF_RoundTrip_WithContext()
+    {
+        var original = new RectangleF(10f, 20f, 100f, 200f);
+        var json = JsonSerializer.Serialize(original, ExtendedJsonSerializerContext.Default.RectangleF);
+        var deserialized = JsonSerializer.Deserialize(json, ExtendedJsonSerializerContext.Default.RectangleF);
+        Assert.Equal(original, deserialized);
+    }
+
+    [Fact]
+    public void Thickness_RoundTrip_WithContext()
+    {
+        var original = new Thickness(1, 2, 3, 4);
+        var json = JsonSerializer.Serialize(original, ExtendedJsonSerializerContext.Default.Thickness);
+        var deserialized = JsonSerializer.Deserialize(json, ExtendedJsonSerializerContext.Default.Thickness);
+        Assert.Equal(original, deserialized);
+    }
+
+    [Fact]
+    public void Size_RoundTrip_WithContext()
+    {
+        var original = new Size(64, 128);
+        var json = JsonSerializer.Serialize(original, ExtendedJsonSerializerContext.Default.Size);
+        var deserialized = JsonSerializer.Deserialize(json, ExtendedJsonSerializerContext.Default.Size);
+        Assert.Equal(original, deserialized);
+    }
+
+    [Fact]
+    public void SizeF_RoundTrip_WithContext()
+    {
+        var original = new SizeF(32.5f, 64.25f);
+        var json = JsonSerializer.Serialize(original, ExtendedJsonSerializerContext.Default.SizeF);
+        var deserialized = JsonSerializer.Deserialize(json, ExtendedJsonSerializerContext.Default.SizeF);
+        Assert.Equal(original, deserialized);
+    }
+
+    [Fact]
+    public void Interval_Int_RoundTrip_WithContext()
+    {
+        var original = new Interval<int>(5, 15);
+        var json = JsonSerializer.Serialize(original, ExtendedJsonSerializerContext.Default.IntervalInt32);
+        var deserialized = JsonSerializer.Deserialize(json, ExtendedJsonSerializerContext.Default.IntervalInt32);
+        Assert.Equal(original.Min, deserialized.Min);
+        Assert.Equal(original.Max, deserialized.Max);
+    }
+
+    [Fact]
+    public void Interval_Float_RoundTrip_WithContext()
+    {
+        var original = new Interval<float>(1.5f, 9.5f);
+        var json = JsonSerializer.Serialize(original, ExtendedJsonSerializerContext.Default.IntervalSingle);
+        var deserialized = JsonSerializer.Deserialize(json, ExtendedJsonSerializerContext.Default.IntervalSingle);
+        Assert.Equal(original.Min, deserialized.Min);
+        Assert.Equal(original.Max, deserialized.Max);
+    }
+
+    [Fact]
+    public void Interval_HslColor_RoundTrip_WithContext()
+    {
+        var min = HslColor.FromRgb(Color.Red);
+        var max = HslColor.FromRgb(Color.Blue);
+        var original = new Interval<HslColor>(min, max);
+        var json = JsonSerializer.Serialize(original, ExtendedJsonSerializerContext.Default.IntervalHslColor);
+        var deserialized = JsonSerializer.Deserialize(json, ExtendedJsonSerializerContext.Default.IntervalHslColor);
+        Assert.Equal(HslColor.ToRgb(original.Min), HslColor.ToRgb(deserialized.Min));
+        Assert.Equal(HslColor.ToRgb(original.Max), HslColor.ToRgb(deserialized.Max));
+    }
+
+    [Fact]
+    public void Interval_Int_RoundTrip_BareOptions()
+    {
+        var options = new JsonSerializerOptions();
+        options.Converters.Add(new IntervalJsonConverter<int>());
+        var original = new Interval<int>(10, 20);
+        var json = JsonSerializer.Serialize(original, options);
+        var deserialized = JsonSerializer.Deserialize<Interval<int>>(json, options);
+        Assert.Equal(original.Min, deserialized.Min);
+        Assert.Equal(original.Max, deserialized.Max);
+    }
+
+    [Fact]
+    public void MultiDimensional_Float_ArrayAndDelimited()
+    {
+        var options = new JsonSerializerOptions();
+
+        var jsonArray = "[1.5, 2.5, 3.5]";
+        var readerArray = new Utf8JsonReader(Encoding.UTF8.GetBytes(jsonArray));
+        readerArray.Read();
+        var arrayResult = readerArray.ReadAsMultiDimensional<float>(options);
+        Assert.Equal(new[] { 1.5f, 2.5f, 3.5f }, arrayResult);
+
+        var jsonDelimited = "\"1.5 2.5 3.5\"";
+        var readerDelimited = new Utf8JsonReader(Encoding.UTF8.GetBytes(jsonDelimited));
+        readerDelimited.Read();
+        var delimitedResult = readerDelimited.ReadAsMultiDimensional<float>(options);
+        Assert.Equal(new[] { 1.5f, 2.5f, 3.5f }, delimitedResult);
+
+        var jsonSingle = "42.5";
+        var readerSingle = new Utf8JsonReader(Encoding.UTF8.GetBytes(jsonSingle));
+        readerSingle.Read();
+        var singleResult = readerSingle.ReadAsMultiDimensional<float>(options);
+        Assert.Equal(new[] { 42.5f }, singleResult);
+    }
+
+    [Fact]
+    public void MultiDimensional_Int_ArrayAndDelimited()
+    {
+        var options = new JsonSerializerOptions();
+
+        var jsonArray = "[10, 20, 30]";
+        var readerArray = new Utf8JsonReader(Encoding.UTF8.GetBytes(jsonArray));
+        readerArray.Read();
+        var arrayResult = readerArray.ReadAsMultiDimensional<int>(options);
+        Assert.Equal(new[] { 10, 20, 30 }, arrayResult);
+
+        var jsonDelimited = "\"10 20 30\"";
+        var readerDelimited = new Utf8JsonReader(Encoding.UTF8.GetBytes(jsonDelimited));
+        readerDelimited.Read();
+        var delimitedResult = readerDelimited.ReadAsMultiDimensional<int>(options);
+        Assert.Equal(new[] { 10, 20, 30 }, delimitedResult);
+
+        var jsonSingle = "100";
+        var readerSingle = new Utf8JsonReader(Encoding.UTF8.GetBytes(jsonSingle));
+        readerSingle.Read();
+        var singleResult = readerSingle.ReadAsMultiDimensional<int>(options);
+        Assert.Equal(new[] { 100 }, singleResult);
+    }
+
+    [Fact]
+    public void MultiDimensional_WithJsonTypeInfo()
+    {
+        var jsonArray = "[1.0, 2.0]";
+        var reader = new Utf8JsonReader(Encoding.UTF8.GetBytes(jsonArray));
+        reader.Read();
+        var result = reader.ReadAsMultiDimensional(ExtendedJsonSerializerContext.Default.Single);
+        Assert.Equal(new[] { 1.0f, 2.0f }, result);
+    }
+
+    [Fact]
+    public void TexturePackerFileReader_ReadStream_DeserializesCorrectly()
+    {
+        var sampleJson = """
+        {
+            "frames": [
+                {
+                    "filename": "antihero-idle.png",
+                    "frame": { "x": 0, "y": 0, "w": 32, "h": 32 },
+                    "rotated": false,
+                    "trimmed": false,
+                    "spriteSourceSize": { "x": 0, "y": 0, "w": 32, "h": 32 },
+                    "sourceSize": { "w": 32, "h": 32 },
+                    "pivot": { "x": 0.5, "y": 0.5 }
+                }
+            ],
+            "textures": [],
+            "meta": {
+                "app": "TexturePacker",
+                "version": "1.0",
+                "image": "spritesheet.png",
+                "format": "RGBA8888",
+                "size": { "w": 64, "h": 64 },
+                "scale": "1",
+                "smartupdate": "abc"
+            }
+        }
+        """;
+
+        using var stream = new MemoryStream(Encoding.UTF8.GetBytes(sampleJson));
+        var content = TexturePackerFileReader.Read(stream);
+
+        Assert.NotNull(content);
+        Assert.Single(content.Regions);
+        Assert.Equal("antihero-idle.png", content.Regions[0].FileName);
+        Assert.Equal(32, content.Regions[0].Frame.Width);
+        Assert.Equal("spritesheet.png", content.Meta.Image);
+    }
+
+#if !FNA && !KNI
+    [Fact]
+    public void JsonContentTypeReader_Register_WithJsonTypeInfo()
+    {
+        JsonContentTypeReader<Vector2>.Register(ExtendedJsonSerializerContext.Default.Vector2);
+    }
+#endif
+}


### PR DESCRIPTION
## Description

* Refactoring Json serialization/deserialization to be Native AOT compatible.

## Related Issues/Tickets

* Closes #1198

## Changes Made

* Adding `ExtendedJsonSerializerContext`.
* Updating `JsonContentTypeReader`.
* Adding `TexturePackerJsonSerializerContext`.
* Updating `TexturePackerFileReader`.
* Marking `BaseTypeJsonConverter` obsolete.
* Updating `IntervalJsonConverter`.
* Updating `JsonContentLoader`.
* Updating `MonoGameJsonSerializerOptionsProvider` to use the new contexts.
* Updating `TextureAtlasJsonConverter`.
* Updating `Utf8JsonReaderExtensions`.
* Adding `JsonSerializerTests`.
* Enabling `IsAotCompatible` in `KNI.Extended.ccsproj`.

## Checklist

Please read and check the following items.  Pull requests will not be reviewed if all items are not checked.

* [x] I have verified that there are no existing pull requests that would overlap with this pull request.
* [x] I have verified that I am following the guidelines as outlined in this project's contribution policy
* [x] I have verified that this pull request adheres to this project's code of conduct.
* [x] I have written a descriptive title for this pull request.
* [x] I have provided appropriate test coverage were applicable.
